### PR TITLE
ci: add typecheck job to CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,3 +40,18 @@ jobs:
         shell: bash
         run: |
           pnpm prettier . --check
+
+  typecheck:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup
+        uses: ./.github/composite-actions/cache-and-install
+
+      - name: Format
+        shell: bash
+        run: |
+          pnpm astro check

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,12 @@
 {
-  "extends": "@tsconfig/strictest/tsconfig.json",
+  "extends": "astro/tsconfigs/strictest",
   "exclude": ["dist"],
   "compilerOptions": {
-    "composite": true,
     "tsBuildInfoFile": "tsconfig.tsbuildinfo",
     "target": "es2022",
     "module": "preserve",
-    "moduleResolution": "bundler",
     "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
     "types": ["./worker-configuration.d.ts", "node"],
-    "verbatimModuleSyntax": true,
-    "jsx": "preserve",
     "plugins": [
       {
         "name": "@astrojs/ts-plugin"


### PR DESCRIPTION
CIに `pnpm astro check` を実行する typecheck job を追加。

変更内容:
- `.github/workflows/ci.yaml`: typecheck job追加
- `tsconfig.json`: `astro/tsconfigs/strictest` をextendし、重複オプションを削除