### PR TITLE
Add GitHub Action to deploy Cloudflare Pages preview for PRs

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,0 +1,70 @@
+name: Preview Deploy
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: preview-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy Cloudflare Pages preview
+    runs-on: ubuntu-24.04
+    if: ${{ !github.event.pull_request.draft }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup
+        uses: ./.github/composite-actions/cache-and-install
+
+      - name: Build
+        shell: bash
+        run: |
+          pnpm astro build
+
+      - name: Deploy Pages preview
+        id: deploy-pages-preview
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: >-
+            pages deploy ./dist
+            --project-name portfolio
+            --branch=${{ github.head_ref }}
+
+      - name: Create preview comment
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy-pages-preview.outputs.deployment-url }}
+          DEPLOYMENT_ALIAS_URL: ${{ steps.deploy-pages-preview.outputs.deployment-alias-url }}
+        shell: bash
+        run: |
+          cat <<EOF_COMMENT > comment.md
+          ## Cloudflare Pages Preview
+
+          | Item | URL |
+          | --- | --- |
+          | Preview deployment | <$DEPLOYMENT_URL> |
+          | Branch alias | <$DEPLOYMENT_ALIAS_URL> |
+          EOF_COMMENT
+
+      - name: Comment on pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} --body-file comment.md


### PR DESCRIPTION
### Motivation
- Provide per-PR preview deployments so changes can be reviewed on a live Cloudflare Pages preview site before merging. 
- Automate build and deploy of the `./dist` output from `astro` and post the preview URL back to the PR to speed up review.

### Description
- Add `.github/workflows/preview.yaml` that runs on `pull_request` events targeting `main` (`opened`, `synchronize`, `reopened`, `ready_for_review`) and skips draft PRs via `if: ${{ !github.event.pull_request.draft }}`. 
- Use the existing setup composite action at `./.github/composite-actions/cache-and-install` and run `pnpm astro build` to produce `./dist`. 
- Deploy the build to Cloudflare Pages with `cloudflare/wrangler-action@v3` using the command `pages deploy ./dist --project-name portfolio --branch=${{ github.head_ref }}` and require the `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` secrets. 
- Post a PR comment with the `deployment-url` and `deployment-alias-url` outputs from the deploy step using `gh pr comment`, and configure `permissions` and a per-PR `concurrency` group to avoid duplicate in-flight previews. 

### Testing
- `pnpm prettier .github/workflows/preview.yaml --check` completed successfully. 
- `pnpm astro check` completed successfully with no errors. 
- `pnpm astro build` completed successfully and generated the `./dist` output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57112886e0832ba7889c0c99f3dc89)