### PR TITLE
chore: update prettier trailingComma to 'none' and apply formatting

### DIFF
--- a/.agents/skills/modern-web-guidance/guides/built-in-ai/language-detection.md
+++ b/.agents/skills/modern-web-guidance/guides/built-in-ai/language-detection.md
@@ -33,7 +33,7 @@ if (availability !== 'unavailable') {
         m.addEventListener('downloadprogress', e => {
           console.log(`Downloaded ${e.loaded * 100}%`);
         });
-      },
+      }
     });
   });
 }

--- a/.agents/skills/modern-web-guidance/guides/built-in-ai/language-model.md
+++ b/.agents/skills/modern-web-guidance/guides/built-in-ai/language-model.md
@@ -26,7 +26,7 @@ if (availability !== 'unavailable') {
       m.addEventListener('downloadprogress', e => {
         console.log(`Downloaded ${e.loaded * 100}%`);
       });
-    },
+    }
   });
 }
 ```
@@ -68,7 +68,7 @@ The Prompt API supports text, audio, and visual inputs (images, canvas, video fr
 const session = await LanguageModel.create({
   // Declaring expected input types lets the browser optimize model loading.
   expectedInputs: [{ type: 'text' }, { type: 'image' }],
-  expectedOutputs: [{ type: 'text' }],
+  expectedOutputs: [{ type: 'text' }]
 });
 
 const response = await session.prompt([
@@ -76,9 +76,9 @@ const response = await session.prompt([
     role: 'user',
     content: [
       { type: 'text', value: 'What is in this image?' },
-      { type: 'image', value: document.querySelector('canvas') },
-    ],
-  },
+      { type: 'image', value: document.querySelector('canvas') }
+    ]
+  }
 ]);
 ```
 
@@ -96,7 +96,7 @@ Cloning is efficient for starting parallel conversations that share the same ini
 
 ```javascript
 const mainSession = await LanguageModel.create({
-  initialPrompts: [{ role: 'system', content: 'You speak like a pirate.' }],
+  initialPrompts: [{ role: 'system', content: 'You speak like a pirate.' }]
 });
 
 const branchA = await mainSession.clone();
@@ -115,7 +115,7 @@ While a native "restore" feature is in development, you can recreate a session b
 // || '[]' ensures JSON.parse never receives null when the key doesn't exist yet.
 const history = JSON.parse(localStorage.getItem('chat_history') || '[]');
 const session = await LanguageModel.create({
-  initialPrompts: history, // Array of {role, content} objects
+  initialPrompts: history // Array of {role, content} objects
 });
 ```
 
@@ -131,13 +131,13 @@ const schema = {
   type: 'object',
   properties: {
     rating: { type: 'number', minimum: 1, maximum: 5 },
-    is_positive: { type: 'boolean' },
+    is_positive: { type: 'boolean' }
   },
-  required: ['rating', 'is_positive'],
+  required: ['rating', 'is_positive']
 };
 
 const result = await session.prompt("Rate the following feedback: 'The food was great!'", {
-  responseConstraint: schema,
+  responseConstraint: schema
 });
 
 const data = JSON.parse(result);
@@ -151,7 +151,7 @@ You can guide the model further by prefilling the assistant's response using `pr
 ````javascript
 const character = await session.prompt([
   { role: 'user', content: 'Create a character sheet' },
-  { role: 'assistant', content: '```json\n', prefix: true },
+  { role: 'assistant', content: '```json\n', prefix: true }
 ]);
 ````
 

--- a/.agents/skills/modern-web-guidance/guides/built-in-ai/prompt-api.md
+++ b/.agents/skills/modern-web-guidance/guides/built-in-ai/prompt-api.md
@@ -26,7 +26,7 @@ if (availability !== 'unavailable') {
       m.addEventListener('downloadprogress', e => {
         console.log(`Downloaded ${e.loaded * 100}%`);
       });
-    },
+    }
   });
 }
 ```
@@ -68,7 +68,7 @@ The Prompt API supports text, audio, and visual inputs (images, canvas, video fr
 const session = await LanguageModel.create({
   // Declaring expected input types lets the browser optimize model loading.
   expectedInputs: [{ type: 'text' }, { type: 'image' }],
-  expectedOutputs: [{ type: 'text' }],
+  expectedOutputs: [{ type: 'text' }]
 });
 
 const response = await session.prompt([
@@ -76,9 +76,9 @@ const response = await session.prompt([
     role: 'user',
     content: [
       { type: 'text', value: 'What is in this image?' },
-      { type: 'image', value: document.querySelector('canvas') },
-    ],
-  },
+      { type: 'image', value: document.querySelector('canvas') }
+    ]
+  }
 ]);
 ```
 
@@ -96,7 +96,7 @@ Cloning is efficient for starting parallel conversations that share the same ini
 
 ```javascript
 const mainSession = await LanguageModel.create({
-  initialPrompts: [{ role: 'system', content: 'You speak like a pirate.' }],
+  initialPrompts: [{ role: 'system', content: 'You speak like a pirate.' }]
 });
 
 const branchA = await mainSession.clone();
@@ -115,7 +115,7 @@ While a native "restore" feature is in development, you can recreate a session b
 // || '[]' ensures JSON.parse never receives null when the key doesn't exist yet.
 const history = JSON.parse(localStorage.getItem('chat_history') || '[]');
 const session = await LanguageModel.create({
-  initialPrompts: history, // Array of {role, content} objects
+  initialPrompts: history // Array of {role, content} objects
 });
 ```
 
@@ -131,13 +131,13 @@ const schema = {
   type: 'object',
   properties: {
     rating: { type: 'number', minimum: 1, maximum: 5 },
-    is_positive: { type: 'boolean' },
+    is_positive: { type: 'boolean' }
   },
-  required: ['rating', 'is_positive'],
+  required: ['rating', 'is_positive']
 };
 
 const result = await session.prompt("Rate the following feedback: 'The food was great!'", {
-  responseConstraint: schema,
+  responseConstraint: schema
 });
 
 const data = JSON.parse(result);
@@ -151,7 +151,7 @@ You can guide the model further by prefilling the assistant's response using `pr
 ````javascript
 const character = await session.prompt([
   { role: 'user', content: 'Create a character sheet' },
-  { role: 'assistant', content: '```json\n', prefix: true },
+  { role: 'assistant', content: '```json\n', prefix: true }
 ]);
 ````
 

--- a/.agents/skills/modern-web-guidance/guides/built-in-ai/summarizer.md
+++ b/.agents/skills/modern-web-guidance/guides/built-in-ai/summarizer.md
@@ -27,7 +27,7 @@ Check if the model is ready, needs downloading, or is unavailable.
 const options = {
   type: 'key-points',
   format: 'plain-text',
-  length: 'medium',
+  length: 'medium'
 };
 
 const availability = await Summarizer.availability(options);
@@ -44,7 +44,7 @@ if (availability === 'available') {
         m.addEventListener('downloadprogress', e => {
           console.log(`Downloaded ${Math.round((e.loaded / e.total) * 100)}%`);
         });
-      },
+      }
     });
   });
 }
@@ -69,7 +69,7 @@ const options = {
   sharedContext: 'This is a scientific article',
   type: 'key-points',
   format: 'markdown',
-  length: 'medium',
+  length: 'medium'
 };
 
 if (navigator.userActivation.isActive) {
@@ -86,7 +86,7 @@ summary request.
 const summarizer = await Summarizer.create({
   type: 'key-points',
   expectedInputLanguages: ['en', 'ja'],
-  outputLanguage: 'es',
+  outputLanguage: 'es'
 });
 ```
 
@@ -99,7 +99,7 @@ Processes the entire text at once and returns the result.
 ```javascript
 const longText = document.querySelector('article').innerText;
 const summary = await summarizer.summarize(longText, {
-  context: 'This article is intended for a tech-savvy audience.',
+  context: 'This article is intended for a tech-savvy audience.'
 });
 console.log(summary);
 ```

--- a/.agents/skills/modern-web-guidance/guides/built-in-ai/translator.md
+++ b/.agents/skills/modern-web-guidance/guides/built-in-ai/translator.md
@@ -32,7 +32,7 @@ To run Gemini Nano and associated models, the system needs:
 ```javascript
 const options = {
   sourceLanguage: 'es',
-  targetLanguage: 'fr',
+  targetLanguage: 'fr'
 };
 
 const availability = await Translator.availability(options);
@@ -46,7 +46,7 @@ if (availability === 'available' || availability === 'downloadable') {
         m.addEventListener('downloadprogress', e => {
           console.log(`Downloaded ${Math.round(e.loaded * 100)}%`);
         });
-      },
+      }
     });
   });
 }
@@ -61,7 +61,7 @@ The API supports both static and streaming responses.
 ```javascript
 const translator = await Translator.create({
   sourceLanguage: 'en',
-  targetLanguage: 'fr',
+  targetLanguage: 'fr'
 });
 
 const result = await translator.translate('Where is the next bus stop, please?');

--- a/.agents/skills/modern-web-guidance/guides/canvas/export-html-media-from-canvas.md
+++ b/.agents/skills/modern-web-guidance/guides/canvas/export-html-media-from-canvas.md
@@ -78,7 +78,7 @@ canvas.onpaint = () => {
       const destDict = {
         destination: { texture: targetTexture },
         width: 512,
-        height: 128,
+        height: 128
       };
       root.device.queue.copyElementImageToTexture(sourceDict, destDict);
     } catch (err) {

--- a/.agents/skills/modern-web-guidance/guides/canvas/expose-canvas-content-to-browser-features.md
+++ b/.agents/skills/modern-web-guidance/guides/canvas/expose-canvas-content-to-browser-features.md
@@ -79,7 +79,7 @@ canvas.onpaint = () => {
       const destDict = {
         destination: { texture: targetTexture },
         width: 512,
-        height: 128,
+        height: 128
       };
       root.device.queue.copyElementImageToTexture(sourceDict, destDict);
     } catch (err) {
@@ -305,7 +305,7 @@ targetHTMLElement.style.transform = computedTransform.toString();
         const destDict = {
           destination: { texture: targetTexture },
           width: width,
-          height: height,
+          height: height
         };
         device.queue.copyElementImageToTexture(sourceDict, destDict);
       } catch (err) {

--- a/.agents/skills/modern-web-guidance/guides/canvas/interactive-content-in-3d-scenes.md
+++ b/.agents/skills/modern-web-guidance/guides/canvas/interactive-content-in-3d-scenes.md
@@ -72,7 +72,7 @@ canvas.onpaint = () => {
       const destDict = {
         destination: { texture: targetTexture },
         width: 512,
-        height: 128,
+        height: 128
       };
       root.device.queue.copyElementImageToTexture(sourceDict, destDict);
     } catch (err) {
@@ -263,7 +263,7 @@ scene.add(mesh);
         const destDict = {
           destination: { texture: targetTexture },
           width: width,
-          height: height,
+          height: height
         };
         device.queue.copyElementImageToTexture(sourceDict, destDict);
       } catch (err) {

--- a/.agents/skills/modern-web-guidance/guides/css/style-parent-with-has.md
+++ b/.agents/skills/modern-web-guidance/guides/css/style-parent-with-has.md
@@ -170,7 +170,7 @@ form.addEventListener(
     const hasError = container.querySelector('.user-invalid-fallback');
     container.classList.toggle('has-error-fallback', !!hasError);
   },
-  true,
+  true
 ); // Capture phase to ensure we run after the fallback's blur listener
 
 // Also handle input events for immediate cleanup

--- a/.agents/skills/modern-web-guidance/guides/datetime/support-global-calendar-systems.md
+++ b/.agents/skills/modern-web-guidance/guides/datetime/support-global-calendar-systems.md
@@ -57,7 +57,7 @@ console.log(`Timeline: ${relative}`);
 const localizedDisplay = targetDate.toLocaleString('en-u-ca-hebrew', {
   day: 'numeric',
   month: 'long',
-  year: 'numeric',
+  year: 'numeric'
 });
 ```
 

--- a/.agents/skills/modern-web-guidance/guides/forms/required-field-feedback.md
+++ b/.agents/skills/modern-web-guidance/guides/forms/required-field-feedback.md
@@ -87,7 +87,7 @@ form.addEventListener(
       syncAriaInvalid(e.target);
     }
   },
-  true,
+  true
 );
 
 // Sync all required fields when submission is attempted

--- a/.agents/skills/modern-web-guidance/guides/html/custom-button-actions.md
+++ b/.agents/skills/modern-web-guidance/guides/html/custom-button-actions.md
@@ -43,7 +43,7 @@ For custom, application-specific actions, you can define your own command names.
       document.querySelectorAll(`button[commandfor="${target.id}"]`).forEach(btn => {
         btn.setAttribute('aria-pressed', 'false');
       });
-    },
+    }
   };
 
   // 2. **Mandatory:** Listen for the 'command' event directly on the target element
@@ -123,7 +123,7 @@ If you prefer not to use a polyfill, you can use a combination of **event delega
 const commandRegistry = {
   '--spin': target => target.classList.toggle('is-spun'),
   '--grow': target => target.classList.toggle('is-grown'),
-  '--reset': target => target.classList.remove('is-spun', 'is-grown'),
+  '--reset': target => target.classList.remove('is-spun', 'is-grown')
 };
 
 // 2. If CommandEvent doesn't exist, we assume no native support and provide the fallback
@@ -149,8 +149,8 @@ document.addEventListener('click', event => {
     target.dispatchEvent(
       new CommandEvent('command', {
         command,
-        source: button,
-      }),
+        source: button
+      })
     );
   }
 });

--- a/.agents/skills/modern-web-guidance/guides/motion/animate-element-entry-exit.md
+++ b/.agents/skills/modern-web-guidance/guides/motion/animate-element-entry-exit.md
@@ -77,7 +77,7 @@ if (animations.length > 0) {
   await Promise.race([
     // Promise.allSettled ensures we wait even if some animations fail
     Promise.allSettled(animations.map(a => a.finished)),
-    new Promise(r => setTimeout(r, 2000)),
+    new Promise(r => setTimeout(r, 2000))
   ]);
 }
 
@@ -129,6 +129,6 @@ el.addEventListener(
   () => {
     if (el.classList.contains('hidden')) el.style.display = 'none';
   },
-  { once: true },
+  { once: true }
 );
 ```

--- a/.agents/skills/modern-web-guidance/guides/motion/cross-document-transitions.md
+++ b/.agents/skills/modern-web-guidance/guides/motion/cross-document-transitions.md
@@ -72,7 +72,7 @@ window.addEventListener('pagereveal', async e => {
     // Use application-specific logic to compute a transition type
     const transitionType = yourTransitionTypeLogic(
       navigation.activation.from,
-      navigation.activation.entry,
+      navigation.activation.entry
     );
     e.viewTransition.types.add(transitionType);
   }

--- a/.agents/skills/modern-web-guidance/guides/motion/directional-navigation-transitions.md
+++ b/.agents/skills/modern-web-guidance/guides/motion/directional-navigation-transitions.md
@@ -85,7 +85,7 @@ const updateDOM = yourUpdateDOMLogic();
 
 document.startViewTransition({
   update: updateDOM,
-  types: [transitionType], // Matches the CSS :active-view-transition-type() selectors
+  types: [transitionType] // Matches the CSS :active-view-transition-type() selectors
 });
 ```
 
@@ -126,7 +126,7 @@ function navigate(updateDOM, direction) {
   // Start transition with the specific navigation type
   document.startViewTransition({
     update: updateDOM,
-    types: [direction], // Matches the CSS :active-view-transition-type() selectors
+    types: [direction] // Matches the CSS :active-view-transition-type() selectors
   });
 }
 ```

--- a/.agents/skills/modern-web-guidance/guides/motion/dynamic-sibling-animations.md
+++ b/.agents/skills/modern-web-guidance/guides/motion/dynamic-sibling-animations.md
@@ -41,7 +41,7 @@ To support stagger animations in older browsers, use JavaScript to add a `--sibl
 if (!CSS.supports('animation-delay: calc(sibling-index() * 0.1s)')) {
   const staggerList = document.getElementById('stagger-list');
   [...staggerList.children].forEach((el, index) =>
-    el.style.setProperty('--sibling-index', index + 1),
+    el.style.setProperty('--sibling-index', index + 1)
   );
 }
 ```

--- a/.agents/skills/modern-web-guidance/guides/motion/physics-based-easing.md
+++ b/.agents/skills/modern-web-guidance/guides/motion/physics-based-easing.md
@@ -165,10 +165,10 @@ if (!supportsLinearEasing) {
         '.element',
         { transform: 'scale(1.2)' },
         {
-          easing: spring({ stiffness: 100, damping: 10 }),
-        },
+          easing: spring({ stiffness: 100, damping: 10 })
+        }
       );
-    },
+    }
   );
 }
 ```

--- a/.agents/skills/modern-web-guidance/guides/overlays/declarative-dialog-popover-control.md
+++ b/.agents/skills/modern-web-guidance/guides/overlays/declarative-dialog-popover-control.md
@@ -143,7 +143,7 @@ If you prefer not to use a polyfill, you can use a combination of **event delega
 const commandRegistry = {
   '--spin': target => target.classList.toggle('is-spun'),
   '--grow': target => target.classList.toggle('is-grown'),
-  '--reset': target => target.classList.remove('is-spun', 'is-grown'),
+  '--reset': target => target.classList.remove('is-spun', 'is-grown')
 };
 
 // 2. If CommandEvent doesn't exist, we assume no native support and provide the fallback
@@ -169,8 +169,8 @@ document.addEventListener('click', event => {
     target.dispatchEvent(
       new CommandEvent('command', {
         command,
-        source: button,
-      }),
+        source: button
+      })
     );
   }
 });
@@ -216,7 +216,7 @@ For projects without a bundler, dynamically import the polyfill directly from a 
     import('https://unpkg.com/@oddbird/popover-polyfill@latest/dist/popover-fn.js').then(
       ({ apply }) => {
         apply();
-      },
+      }
     );
   }
 </script>

--- a/.agents/skills/modern-web-guidance/guides/overlays/navigation-drawer.md
+++ b/.agents/skills/modern-web-guidance/guides/overlays/navigation-drawer.md
@@ -260,7 +260,7 @@ const observer = new IntersectionObserver(
   // root: drawer makes the popover element the intersection root,
   // so the ratio reflects the sheet's visibility within the popover
   // (i.e. how much of it has been swiped on-screen).
-  { root: drawer, threshold: [visibleThreshold, 1] },
+  { root: drawer, threshold: [visibleThreshold, 1] }
 );
 observer.observe(sheet);
 ```

--- a/.agents/skills/modern-web-guidance/guides/overlays/position-aware-tooltips.md
+++ b/.agents/skills/modern-web-guidance/guides/overlays/position-aware-tooltips.md
@@ -145,7 +145,7 @@ If you are not using a package manager, dynamically import the polyfill directly
     import('https://unpkg.com/@oddbird/popover-polyfill@latest/dist/popover-fn.js').then(
       ({ apply }) => {
         apply();
-      },
+      }
     );
   }
 </script>

--- a/.agents/skills/modern-web-guidance/guides/passkeys/passkey-authentication.md
+++ b/.agents/skills/modern-web-guidance/guides/passkeys/passkey-authentication.md
@@ -20,7 +20,7 @@ const options = {
   challenge: serverGeneratedBase64UrlChallenge, // High-entropy random challenge stored in session
   rpId: 'example.com',
   allowCredentials: [], // Request discoverable passkeys
-  userVerification: 'preferred',
+  userVerification: 'preferred'
 };
 
 // Persist expected UV level to user session
@@ -95,7 +95,7 @@ async function initializeConditionalAutofill() {
       const credential = await navigator.credentials.get({
         publicKey,
         signal: autofillAbortController.signal,
-        mediation: 'conditional',
+        mediation: 'conditional'
       });
 
       // Segregated verification fetch
@@ -106,7 +106,7 @@ async function initializeConditionalAutofill() {
         if (PublicKeyCredential.signalUnknownCredential) {
           await PublicKeyCredential.signalUnknownCredential({
             rpId, // RP ID must match the one defined on the server
-            credentialId: encoded.id,
+            credentialId: encoded.id
           });
         }
       }
@@ -133,7 +133,7 @@ async function triggerButtonAuthentication() {
     // Passkey explicit prompt trigger
     credential = await navigator.credentials.get({
       publicKey,
-      signal: autofillAbortController.signal,
+      signal: autofillAbortController.signal
     });
   } catch (err) {
     if (err.name === 'NotAllowedError') {
@@ -154,7 +154,7 @@ async function triggerButtonAuthentication() {
       // Note: this code path runs pre-authentication, satisfying the unauth precondition
       await PublicKeyCredential.signalUnknownCredential({
         rpId, // RP ID must match the one defined on the server
-        credentialId: encoded.id, // Base64URL-encoded credential ID
+        credentialId: encoded.id // Base64URL-encoded credential ID
       });
     }
   } catch (serverErr) {

--- a/.agents/skills/modern-web-guidance/guides/passkeys/passkey-conditional-create.md
+++ b/.agents/skills/modern-web-guidance/guides/passkeys/passkey-conditional-create.md
@@ -70,7 +70,7 @@ async function triggerConditionalCreate(loginAbortController) {
     // 3. Invoke silent credentials creation prompt
     credential = await navigator.credentials.create({
       publicKey,
-      mediation: 'conditional', // Silent background creation mediation
+      mediation: 'conditional' // Silent background creation mediation
     });
   } catch (e) {
     // 4. Silently swallow common WebAuthn browser exceptions
@@ -90,7 +90,7 @@ async function triggerConditionalCreate(loginAbortController) {
       if (PublicKeyCredential.signalUnknownCredential) {
         await PublicKeyCredential.signalUnknownCredential({
           rpId, // RP ID must match the one defined on the server
-          credentialId: encodedResponse.id,
+          credentialId: encodedResponse.id
         });
       }
     }
@@ -99,7 +99,7 @@ async function triggerConditionalCreate(loginAbortController) {
     if (PublicKeyCredential.signalUnknownCredential) {
       await PublicKeyCredential.signalUnknownCredential({
         rpId, // RP ID must match the one defined on the server
-        credentialId: encodedResponse.id,
+        credentialId: encodedResponse.id
       });
     }
   }

--- a/.agents/skills/modern-web-guidance/guides/passkeys/passkey-management.md
+++ b/.agents/skills/modern-web-guidance/guides/passkeys/passkey-management.md
@@ -83,7 +83,7 @@ async function syncAcceptedCredentials(currentCredentialsList) {
     await PublicKeyCredential.signalAllAcceptedCredentials({
       rpId, // RP ID must match the one defined on the server
       userId: base64UrlUserId, // User ID Base64URL-encoded string
-      allAcceptedCredentialIds: credentialIds,
+      allAcceptedCredentialIds: credentialIds
     });
   } catch (e) {
     console.error('SignalAllAcceptedCredentials sync failure:', e);
@@ -119,7 +119,7 @@ async function performRename(rpId, userId, updatedName, updatedDisplayName) {
         rpId, // RP ID must match the one defined on the server
         userId, // Base64URL-encoded user ID
         name: updatedName, // Updated username
-        displayName: updatedDisplayName, // Updated display name
+        displayName: updatedDisplayName // Updated display name
       });
     } catch (e) {
       console.error('SignalCurrentUserDetails sync failure:', e);
@@ -174,7 +174,7 @@ if (aaguid === '00000000-0000-0000-0000-000000000000') {
     // ...other fields
     aaguid,
     name: provider?.name || 'Unknown passkey provider',
-    providerIcon: provider?.icon_light,
+    providerIcon: provider?.icon_light
   };
 }
 ```

--- a/.agents/skills/modern-web-guidance/guides/passkeys/passkey-reauthentication.md
+++ b/.agents/skills/modern-web-guidance/guides/passkeys/passkey-reauthentication.md
@@ -26,8 +26,8 @@ router.post('/api/reauth/options', enforceActiveSession, async (req, res) => {
     allowCredentials: userPasskeys.map(cred => ({
       type: 'public-key',
       id: cred.id,
-      transports: cred.transports, // Speeds up resolution by indicating platform transports
-    })),
+      transports: cred.transports // Speeds up resolution by indicating platform transports
+    }))
   };
   return res.json(options);
 });
@@ -60,7 +60,7 @@ async function triggerButtonReauth() {
   reauthAbortController = new AbortController();
 
   const optionsResponse = await fetch('/api/reauth/options', {
-    method: 'POST',
+    method: 'POST'
   });
   const optionsJSON = await optionsResponse.json();
   const publicKey = PublicKeyCredential.parseRequestOptionsFromJSON(optionsJSON);
@@ -68,7 +68,7 @@ async function triggerButtonReauth() {
   try {
     const credential = await navigator.credentials.get({
       publicKey,
-      signal: reauthAbortController.signal,
+      signal: reauthAbortController.signal
     });
 
     if (credential) {
@@ -76,7 +76,7 @@ async function triggerButtonReauth() {
       const verifyResponse = await fetch('/api/reauth/verify', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(encodedCredential),
+        body: JSON.stringify(encodedCredential)
       });
 
       if (verifyResponse.ok) {
@@ -84,7 +84,7 @@ async function triggerButtonReauth() {
       } else if (verifyResponse.status === 404 && PublicKeyCredential.signalUnknownCredential) {
         await PublicKeyCredential.signalUnknownCredential({
           rpId, // RP ID must match the one defined on the server
-          credentialId: encodedCredential.id,
+          credentialId: encodedCredential.id
         });
       }
     }

--- a/.agents/skills/modern-web-guidance/guides/passkeys/passkey-registration.md
+++ b/.agents/skills/modern-web-guidance/guides/passkeys/passkey-registration.md
@@ -48,29 +48,29 @@ const options = {
   user: {
     id: userBase64UrlId, // Unique base64url string identifying the account
     name: 'user@example.com',
-    displayName: 'Jane Doe',
+    displayName: 'Jane Doe'
   },
   pubKeyCredParams: [
     {
       type: 'public-key',
-      alg: -7,
+      alg: -7
     },
     {
       type: 'public-key',
-      alg: -257,
-    },
+      alg: -257
+    }
   ],
   excludeCredentials: userExistingCredentials.map(cred => ({
     type: 'public-key',
     id: cred.id,
-    transports: cred.transports,
+    transports: cred.transports
   })),
   authenticatorSelection: {
     residentKey: 'required',
     requireResidentKey: true,
     userVerification: 'preferred',
-    ...(isPromotionFlow && { authenticatorAttachment: 'platform' }),
-  },
+    ...(isPromotionFlow && { authenticatorAttachment: 'platform' })
+  }
 };
 ```
 
@@ -139,14 +139,14 @@ async function registerPasskey(isPromotion = false) {
       // Server verification failed to verify/authenticate the credential (orphaned)
       await PublicKeyCredential.signalUnknownCredential({
         rpId, // RP ID must match the one defined on the server
-        credentialId: encodedResponse.id, // Base64URL-encoded credential ID
+        credentialId: encodedResponse.id // Base64URL-encoded credential ID
       });
     }
   } catch (serverErr) {
     console.error('Server verification network failure:', serverErr);
     await publickeycredential.signalunknowncredential({
       rpId, // RP ID must match the one defined on the server
-      credentialid: encodedresponse.id, // base64url-encoded credential id
+      credentialid: encodedresponse.id // base64url-encoded credential id
     });
   }
 }

--- a/.agents/skills/modern-web-guidance/guides/performance/batch-analytics-events.md
+++ b/.agents/skills/modern-web-guidance/guides/performance/batch-analytics-events.md
@@ -59,7 +59,7 @@ function trackEvent(eventData) {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(eventQueue),
       signal: fetchLaterController.signal,
-      activateAfter: BATCH_WINDOW,
+      activateAfter: BATCH_WINDOW
     });
   } catch (error) {
     // Handle errors as needed.
@@ -144,7 +144,7 @@ globalThis.fetchLater ??= function fetchLater(url, init = {}) {
   return {
     get activated() {
       return activated;
-    },
+    }
   };
 };
 ```

--- a/.agents/skills/modern-web-guidance/guides/performance/deprioritize-background-fetches.md
+++ b/.agents/skills/modern-web-guidance/guides/performance/deprioritize-background-fetches.md
@@ -18,7 +18,7 @@ fetch('/api/analytics', {
   method: 'POST',
   body: JSON.stringify(eventData),
   // Lower the priority to prevent network contention
-  priority: 'low',
+  priority: 'low'
 });
 ```
 

--- a/.agents/skills/modern-web-guidance/guides/performance/detect-initial-visibility-state.md
+++ b/.agents/skills/modern-web-guidance/guides/performance/detect-initial-visibility-state.md
@@ -35,7 +35,7 @@ function getVisibilityInfo() {
 
     return {
       initiallyBackgrounded,
-      timeBackgrounded,
+      timeBackgrounded
     };
   }
 }
@@ -81,7 +81,7 @@ function getFallbackVisibilityInfo() {
     },
     get timeBackgrounded() {
       return timeBackgrounded;
-    },
+    }
   };
 }
 

--- a/.agents/skills/modern-web-guidance/guides/performance/efficient-background-processing.md
+++ b/.agents/skills/modern-web-guidance/guides/performance/efficient-background-processing.md
@@ -79,7 +79,7 @@ document.addEventListener(
       }
     }
   },
-  { capture: true },
+  { capture: true }
 );
 ```
 
@@ -117,8 +117,8 @@ if (!isSupported) {
     },
     {
       // Use rootMargin to start rendering before it hits the screen
-      rootMargin: '200px',
-    },
+      rootMargin: '200px'
+    }
   );
 
   observer.observe(target);

--- a/.agents/skills/modern-web-guidance/guides/performance/full-session-analytics.md
+++ b/.agents/skills/modern-web-guidance/guides/performance/full-session-analytics.md
@@ -23,7 +23,7 @@ const ANALYTICS_ENDPOINT = '/path/to/analytics/endpoint';
 
 const sessionData = {
   duration: 0,
-  id: crypto.randomUUID(),
+  id: crypto.randomUUID()
 };
 
 let fetchLaterController = null;
@@ -45,7 +45,7 @@ function queueBeacon() {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(sessionData),
-      signal: fetchLaterController.signal,
+      signal: fetchLaterController.signal
     });
   } catch (error) {
     // Handle errors as needed.
@@ -125,7 +125,7 @@ globalThis.fetchLater ??= function fetchLater(url, init = {}) {
   return {
     get activated() {
       return activated;
-    },
+    }
   };
 };
 ```

--- a/.agents/skills/modern-web-guidance/guides/performance/identify-heavy-scripts.md
+++ b/.agents/skills/modern-web-guidance/guides/performance/identify-heavy-scripts.md
@@ -28,12 +28,12 @@ const observer = new PerformanceObserver(list => {
   const scriptSource = [...new Set(allScripts.map(script => script.sourceURL))];
   const scriptsBySource = scriptSource.map(sourceURL => [
     sourceURL,
-    allScripts.filter(script => script.sourceURL === sourceURL),
+    allScripts.filter(script => script.sourceURL === sourceURL)
   ]);
   const processedScripts = scriptsBySource.map(([sourceURL, scripts]) => ({
     sourceURL,
     count: scripts.length,
-    totalDuration: scripts.reduce((subtotal, script) => subtotal + script.duration, 0),
+    totalDuration: scripts.reduce((subtotal, script) => subtotal + script.duration, 0)
   }));
 
   // Only include scripts above a certain threshold to reduce noise.

--- a/.agents/skills/modern-web-guidance/guides/performance/identify-inp-causes.md
+++ b/.agents/skills/modern-web-guidance/guides/performance/identify-inp-causes.md
@@ -45,8 +45,8 @@ onINP(metric => {
       // subpart indicates which phase (input delay, processing, or
       // presentation delay) the longest script overlapped with most.
       subpart: metric.attribution.longestScript.subpart,
-      intersectingDuration: metric.attribution.longestScript.intersectingDuration,
-    }),
+      intersectingDuration: metric.attribution.longestScript.intersectingDuration
+    })
   );
 });
 ```

--- a/.agents/skills/modern-web-guidance/guides/performance/performance.md
+++ b/.agents/skills/modern-web-guidance/guides/performance/performance.md
@@ -295,7 +295,7 @@ import { CacheableResponsePlugin } from 'workbox-cacheable-response';
 // 1. HTML Documents: Network First
 registerRoute(
   ({ request }) => request.mode === 'navigate',
-  new NetworkFirst({ cacheName: 'pages-cache' }),
+  new NetworkFirst({ cacheName: 'pages-cache' })
 );
 
 // 2. Static Assets (JS, CSS, Fonts): Cache First
@@ -305,9 +305,9 @@ registerRoute(
     cacheName: 'static-resources',
     plugins: [
       new CacheableResponsePlugin({ statuses: [0, 200] }),
-      new ExpirationPlugin({ maxEntries: 50, maxAgeSeconds: 30 * 24 * 60 * 60 }),
-    ],
-  }),
+      new ExpirationPlugin({ maxEntries: 50, maxAgeSeconds: 30 * 24 * 60 * 60 })
+    ]
+  })
 );
 
 // 3. API Responses: Stale While Revalidate
@@ -315,8 +315,8 @@ registerRoute(
   ({ url }) => url.pathname.startsWith('/api/v1/content'),
   new StaleWhileRevalidate({
     cacheName: 'api-cache',
-    plugins: [new CacheableResponsePlugin({ statuses: [0, 200] })],
-  }),
+    plugins: [new CacheableResponsePlugin({ statuses: [0, 200] })]
+  })
 );
 ```
 

--- a/.agents/skills/modern-web-guidance/guides/performance/schedule-tasks-by-priority.md
+++ b/.agents/skills/modern-web-guidance/guides/performance/schedule-tasks-by-priority.md
@@ -15,7 +15,7 @@ scheduler.postTask(
     // DO: Handle critical updates that impact user interaction
     handleCriticalUpdate();
   },
-  { priority: 'user-blocking' },
+  { priority: 'user-blocking' }
 );
 
 // Schedule a default priority task
@@ -30,7 +30,7 @@ scheduler.postTask(
     // DO: Perform heavy background work that is not time-critical
     sendAnalytics();
   },
-  { priority: 'background' },
+  { priority: 'background' }
 );
 ```
 
@@ -63,7 +63,7 @@ function runScheduledTasks() {
     () => {
       console.log('Task with priority support');
     },
-    { priority: 'background' },
+    { priority: 'background' }
   );
 }
 ```

--- a/.agents/skills/modern-web-guidance/guides/performance/sequence-distributed-events.md
+++ b/.agents/skills/modern-web-guidance/guides/performance/sequence-distributed-events.md
@@ -21,7 +21,7 @@ function recordEvent(eventType, nodeId) {
   return {
     nodeId,
     eventType,
-    timestamp: Temporal.Now.instant(), // Nanosecond resolution
+    timestamp: Temporal.Now.instant() // Nanosecond resolution
   };
 }
 

--- a/.agents/skills/modern-web-guidance/guides/privacy/privacy.md
+++ b/.agents/skills/modern-web-guidance/guides/privacy/privacy.md
@@ -185,10 +185,10 @@ try {
         {
           configURL: 'https://idp.example/fedcm.json',
           clientId: 'rp-client-id-123',
-          nonce: 'a_secure_random_nonce_value',
-        },
-      ],
-    },
+          nonce: 'a_secure_random_nonce_value'
+        }
+      ]
+    }
   });
   authenticateWithBackend(credential.token);
 } catch (error) {

--- a/.agents/skills/modern-web-guidance/guides/scroll/carousel-slide-effects.md
+++ b/.agents/skills/modern-web-guidance/guides/scroll/carousel-slide-effects.md
@@ -155,12 +155,12 @@ if (!CSS.supports('(animation-timeline: view()) and (animation-range: entry)')) 
   entries.forEach(entry => {
     const animation = entry.animate(
       {
-        scale: ['0.5', '1', '0.5'],
+        scale: ['0.5', '1', '0.5']
       },
       {
         duration: 1, // We'll control the time ourselves
-        fill: 'both',
-      },
+        fill: 'both'
+      }
     );
     animation.pause();
     animations.set(entry, animation);

--- a/.agents/skills/modern-web-guidance/guides/scroll/carousel-snap-highlights.md
+++ b/.agents/skills/modern-web-guidance/guides/scroll/carousel-snap-highlights.md
@@ -129,8 +129,8 @@ if (!CSS.supports('container-type', 'scroll-state')) {
     {
       root: document.querySelector('.carousel'),
       // Carousel item intersects if any part of the carousel item is in the middle 2% of the carousel.
-      rootMargin: '0px -49%',
-    },
+      rootMargin: '0px -49%'
+    }
   );
 
   document.querySelectorAll('.carousel-item').forEach(item => {

--- a/.agents/skills/modern-web-guidance/guides/scroll/parallax-scroll-effects.md
+++ b/.agents/skills/modern-web-guidance/guides/scroll/parallax-scroll-effects.md
@@ -211,7 +211,7 @@ if (!CSS.supports('(animation-timeline: view()) and (animation-range: entry)')) 
         }
       });
     },
-    { threshold: 0 },
+    { threshold: 0 }
   );
 
   observer.observe(wrapper);

--- a/.agents/skills/modern-web-guidance/guides/scroll/scroll-entry-exit-effects.md
+++ b/.agents/skills/modern-web-guidance/guides/scroll/scroll-entry-exit-effects.md
@@ -165,8 +165,8 @@ For this use-case specifically, the following script applies the fallback for br
         }
       },
       {
-        threshold: Array.from({ length: 101 }, (_, i) => i / 100),
-      },
+        threshold: Array.from({ length: 101 }, (_, i) => i / 100)
+      }
     );
 
     document.querySelectorAll('.scroller > *').forEach(el => {

--- a/.agents/skills/modern-web-guidance/guides/scroll/scroll-position-aware-elements.md
+++ b/.agents/skills/modern-web-guidance/guides/scroll/scroll-position-aware-elements.md
@@ -125,7 +125,7 @@ if (!CSS.supports('container-type', 'scroll-state')) {
         }
       });
     },
-    { root: scroller },
+    { root: scroller }
   );
 
   observer.observe(sentinel);

--- a/.agents/skills/modern-web-guidance/guides/scroll/scroll-snap-realtime-feedback.md
+++ b/.agents/skills/modern-web-guidance/guides/scroll/scroll-snap-realtime-feedback.md
@@ -148,7 +148,7 @@ if ('onscrollsnapchanging' in Element.prototype) {
       clearTimeout(scrollTimeout);
       scrollTimeout = setTimeout(promotePendingToActive, 100);
     },
-    { passive: true },
+    { passive: true }
   );
 
   // Fallback: use Baseline `scrollend` event to promote pending to active cleanly where supported

--- a/.agents/skills/modern-web-guidance/guides/scroll/scrollability-affordance-hints.md
+++ b/.agents/skills/modern-web-guidance/guides/scroll/scrollability-affordance-hints.md
@@ -122,7 +122,7 @@ if (!CSS.supports('container-type', 'scroll-state')) {
         }
       });
     },
-    { root: scroller },
+    { root: scroller }
   );
 
   observer.observe(topSentinel);

--- a/.agents/skills/modern-web-guidance/guides/scroll/scrollytelling.md
+++ b/.agents/skills/modern-web-guidance/guides/scroll/scrollytelling.md
@@ -196,7 +196,7 @@ const observer = new IntersectionObserver(
   entries => {
     entries.forEach(entry => {
       const sectionIndex = Array.from(document.querySelectorAll('#tracked section')).indexOf(
-        entry.target,
+        entry.target
       );
       if (sectionIndex !== -1) {
         const animatedSection = animatedSections[sectionIndex];
@@ -215,7 +215,7 @@ const observer = new IntersectionObserver(
       }
     });
   },
-  { threshold: Array.from({ length: 101 }, (_, i) => i / 100) },
+  { threshold: Array.from({ length: 101 }, (_, i) => i / 100) }
 );
 
 document.querySelectorAll('#tracked section').forEach(section => {

--- a/.agents/skills/modern-web-guidance/guides/scroll/stack-drill-down.md
+++ b/.agents/skills/modern-web-guidance/guides/scroll/stack-drill-down.md
@@ -640,7 +640,7 @@ if (!('onscrollsnapchange' in HTMLElement.prototype)) {
         }
       }
     },
-    { root: stack, threshold: 1 },
+    { root: stack, threshold: 1 }
   );
 
   // Auto-observe every .Stack-view as it's added to the stack, and stop

--- a/.agents/skills/modern-web-guidance/guides/scroll/swipe-to-remove.md
+++ b/.agents/skills/modern-web-guidance/guides/scroll/swipe-to-remove.md
@@ -294,8 +294,8 @@ function setupItem(item) {
     },
     {
       root: track,
-      threshold: [commitThreshold, activateThreshold],
-    },
+      threshold: [commitThreshold, activateThreshold]
+    }
   );
 
   // Return the handle without starting observation; the outer viewport observer

--- a/.agents/skills/modern-web-guidance/guides/security/security.md
+++ b/.agents/skills/modern-web-guidance/guides/security/security.md
@@ -255,7 +255,7 @@ Trusted Types enforces the §1.2 source-level guidance at runtime: once enabled,
 ```javascript
 if (window.trustedTypes && trustedTypes.createPolicy) {
   const policy = trustedTypes.createPolicy('escapePolicy', {
-    createHTML: str => str.replace(/</g, '&lt;').replace(/>/g, '&gt;'),
+    createHTML: str => str.replace(/</g, '&lt;').replace(/>/g, '&gt;')
   });
   el.innerHTML = policy.createHTML(untrustedString);
 }

--- a/.agents/skills/modern-web-guidance/guides/webmcp/agentic-javascript-tools.md
+++ b/.agents/skills/modern-web-guidance/guides/webmcp/agentic-javascript-tools.md
@@ -20,9 +20,9 @@ await document.modelContext.registerTool(
       const prefs = localStorage.getItem('user_prefs');
       return prefs ? JSON.parse(prefs) : { theme: 'light' };
     },
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: true }
   },
-  { signal: controller.signal },
+  { signal: controller.signal }
 );
 
 // To unregister the tool (e.g., on component unmount):
@@ -41,15 +41,15 @@ await document.modelContext.registerTool({
     type: 'object',
     properties: {
       width: { type: 'number', description: 'The width of the rectangle.' },
-      height: { type: 'number', description: 'The height of the rectangle.' },
+      height: { type: 'number', description: 'The height of the rectangle.' }
     },
-    required: ['width', 'height'],
+    required: ['width', 'height']
   },
   execute(input) {
     // input is { width: 10, height: 20 }
     return input.width * input.height;
   },
-  annotations: { readOnlyHint: true },
+  annotations: { readOnlyHint: true }
 });
 ```
 
@@ -96,7 +96,7 @@ export function createInventoryTool(inventoryManager) {
     execute() {
       return inventoryManager.getItems();
     },
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: true }
   };
 }
 ```

--- a/astro.config.mts
+++ b/astro.config.mts
@@ -5,6 +5,6 @@ import { defineConfig, passthroughImageService } from 'astro/config';
 export default defineConfig({
   output: 'static',
   image: {
-    service: passthroughImageService(),
-  },
+    service: passthroughImageService()
+  }
 });

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -13,35 +13,35 @@ export default defineConfig([
       '**/styled-system/*',
       '**/dist/*',
       'postcss.config.cjs',
-      'worker-configuration.d.ts',
-    ],
+      'worker-configuration.d.ts'
+    ]
   },
   {
     files: ['**/*.ts', '**/*.tsx'],
     extends: [
       js.configs.recommended,
       tseslint.configs.strictTypeChecked,
-      tseslint.configs.stylisticTypeChecked,
+      tseslint.configs.stylisticTypeChecked
     ],
     languageOptions: {
       parserOptions: {
-        project: './tsconfig.json',
-      },
-    },
+        project: './tsconfig.json'
+      }
+    }
   },
   ...eslintPluginAstro.configs.recommended,
   ...eslintPluginAstro.configs['jsx-a11y-strict'],
   {
     files: ['**/*.astro/*.ts'],
-    ...tseslint.configs.disableTypeChecked,
+    ...tseslint.configs.disableTypeChecked
   },
   {
     files: ['src/**/*.astro'],
     languageOptions: {
       parserOptions: {
-        project: './tsconfig.json',
-      },
-    },
+        project: './tsconfig.json'
+      }
+    }
   },
-  eslintConfigPrettier,
+  eslintConfigPrettier
 ]);

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+}

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -1,3 +1,3 @@
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://opencode.ai/config.json"
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint:inspect": "eslint-config-inspector",
     "lint": "pnpm run lint:check",
     "format:check": "prettier --check . --cache --cache-location node_modules/.cache/prettier --cache-strategy content",
-    "format": "prettier --check . --cache --cache-location node_modules/.cache/prettier --cache-strategy content",
+    "format": "prettier --write . --cache --cache-location node_modules/.cache/prettier --cache-strategy content",
     "typecheck": "astro check"
   },
   "dependencies": {

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -2,8 +2,8 @@ import { defineConfig, defineGlobalStyles } from '@pandacss/dev';
 
 const globalStyles = defineGlobalStyles({
   ':root, body': {
-    color: '#e0e0e0',
-  },
+    color: '#e0e0e0'
+  }
 });
 
 export default defineConfig({
@@ -22,9 +22,9 @@ export default defineConfig({
     semanticTokens: {
       colors: {
         primary: {
-          value: '#ec93a1',
-        },
-      },
+          value: '#ec93a1'
+        }
+      }
     },
     extend: {
       breakpoints: {
@@ -33,12 +33,12 @@ export default defineConfig({
         md: '768px',
         lg: '1024px',
         xl: '1280px',
-        '2xl': '1536px',
-      },
-    },
+        '2xl': '1536px'
+      }
+    }
   },
 
   globalCss: globalStyles,
   // The output directory for your css system
-  outdir: 'styled-system',
+  outdir: 'styled-system'
 });

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,3 +1,3 @@
 module.exports = {
-  plugins: [require('@pandacss/dev/postcss')()],
+  plugins: [require('@pandacss/dev/postcss')()]
 };

--- a/prettier.config.ts
+++ b/prettier.config.ts
@@ -7,7 +7,7 @@ export default {
   useTabs: false,
   semi: true,
   singleQuote: true,
-  trailingComma: 'all',
+  trailingComma: 'none',
   bracketSpacing: true,
   bracketSameLine: false,
   arrowParens: 'avoid',
@@ -16,8 +16,8 @@ export default {
     {
       files: '*.astro',
       options: {
-        parser: 'astro',
-      },
-    },
-  ],
+        parser: 'astro'
+      }
+    }
+  ]
 } as const satisfies Config;

--- a/src/components/About/About.astro
+++ b/src/components/About/About.astro
@@ -10,7 +10,7 @@ import { css } from '../../../styled-system/css';
     height: '100svb',
     backgroundColor: '#212121',
     paddingInline: { base: '16px', sm: '24px', md: '32px' },
-    paddingBlock: '64px',
+    paddingBlock: '64px'
   })}
 >
 </section>

--- a/src/components/Footer/Footer.astro
+++ b/src/components/Footer/Footer.astro
@@ -15,14 +15,14 @@ import { Image } from 'astro:assets';
     height: '100svb',
     backgroundColor: '#212121',
     paddingInline: { base: '16px', sm: '24px', md: '32px' },
-    paddingBlock: '64px',
+    paddingBlock: '64px'
   })}
 >
   <div
     class={css({
       display: 'flex',
       flexDir: 'column',
-      gap: '32px',
+      gap: '32px'
     })}
   >
     <h1
@@ -35,8 +35,8 @@ import { Image } from 'astro:assets';
         fontSize: {
           base: '1.5em',
           md: '2.5em',
-          lg: '3em',
-        },
+          lg: '3em'
+        }
       })}
     >
       Feel free to contact me!
@@ -46,7 +46,7 @@ import { Image } from 'astro:assets';
         display: 'flex',
         alignItems: 'start',
         flexDir: { base: 'column', md: 'row' },
-        gap: '16px',
+        gap: '16px'
       })}
     >
       <a
@@ -57,7 +57,7 @@ import { Image } from 'astro:assets';
           justifyContent: 'center',
           alignItems: 'center',
           gap: '8px',
-          fontWeight: 700,
+          fontWeight: 700
         })}
       >
         <Image src={GitHubLogo} alt="" width={20} height={20} decoding="async" loading="lazy" />
@@ -71,7 +71,7 @@ import { Image } from 'astro:assets';
           justifyContent: 'center',
           alignItems: 'center',
           gap: '8px',
-          fontWeight: 700,
+          fontWeight: 700
         })}
       >
         <Image src={XLogo} alt="" width={20} height={20} decoding="async" loading="lazy" />
@@ -83,7 +83,7 @@ import { Image } from 'astro:assets';
     class={css({
       position: 'absolute',
       fontSize: { base: '0.75em', md: '1em' },
-      bottom: { base: '12px', md: '32px' },
+      bottom: { base: '12px', md: '32px' }
     })}
   >
     © Copyright 2025, koralle. All Rights Reserved.

--- a/src/components/GetInTouch/GetInTouch.astro
+++ b/src/components/GetInTouch/GetInTouch.astro
@@ -10,7 +10,7 @@ import { css } from '../../../styled-system/css';
     height: '100svb',
     backgroundColor: '#1a1a1a',
     paddingInline: { base: '16px', sm: '24px', md: '32px' },
-    paddingBlock: '64px',
+    paddingBlock: '64px'
   })}
 >
   <h1
@@ -18,7 +18,7 @@ import { css } from '../../../styled-system/css';
       display: 'inline flex',
       justifyContent: 'start',
       alignItems: 'center',
-      color: 'primary',
+      color: 'primary'
     })}
   >
     GetInTouch

--- a/src/components/Hero/Hero.astro
+++ b/src/components/Hero/Hero.astro
@@ -15,7 +15,7 @@ import SleepingMugicha from '../../../public/images/sleeping-mugicha.webp';
     paddingInline: { base: '16px', sm: '24px', md: '32px' },
     paddingBlock: '64px',
     visibility: 'hidden',
-    opacity: 0,
+    opacity: 0
   })}
 >
   <div
@@ -25,7 +25,7 @@ import SleepingMugicha from '../../../public/images/sleeping-mugicha.webp';
       alignItems: 'center',
       width: '100%',
       maxWidth: '1440px',
-      height: '100%',
+      height: '100%'
     })}
   >
     <hgroup>
@@ -33,14 +33,14 @@ import SleepingMugicha from '../../../public/images/sleeping-mugicha.webp';
         id="greeting"
         class={css({
           fontSize: { base: '1.5em', sm: '2.75em', md: '3.25em' },
-          fontWeight: 700,
+          fontWeight: 700
         })}
       >
         Hi! I'm{' '}
         <span
           id="my-name"
           class={css({
-            color: 'primary',
+            color: 'primary'
           })}
         >
           koralle
@@ -52,7 +52,7 @@ import SleepingMugicha from '../../../public/images/sleeping-mugicha.webp';
         class={css({
           fontSize: { base: '1em', sm: '1.5em' },
           color: 'oklch(0.872 0.01 258.338)',
-          fontWeight: 400,
+          fontWeight: 400
         })}
       >
         A seal and a front-end developer.
@@ -63,7 +63,7 @@ import SleepingMugicha from '../../../public/images/sleeping-mugicha.webp';
       class={css({
         display: 'grid',
         placeItems: 'center',
-        width: { base: '192px', md: '320px', lg: '480px', xl: '640px' },
+        width: { base: '192px', md: '320px', lg: '480px', xl: '640px' }
       })}
     >
       <Image src={SleepingMugicha} alt="" />
@@ -79,7 +79,7 @@ import SleepingMugicha from '../../../public/images/sleeping-mugicha.webp';
 
   const startHeroAnimation = () => {
     const splitGreeting = SplitText.create('#greeting', {
-      type: 'words,chars',
+      type: 'words,chars'
     });
 
     gsap.set('#hero', { visibility: 'visible' });
@@ -91,12 +91,12 @@ import SleepingMugicha from '../../../public/images/sleeping-mugicha.webp';
         opacity: 0,
         y: 20,
         stagger: 0.05,
-        duration: 1,
+        duration: 1
       })
       .from('#self-introduction', { opacity: 0, x: -20, duration: 0.5 });
   };
 
   document.addEventListener('loader-animation-finished', startHeroAnimation, {
-    once: true,
+    once: true
   });
 </script>

--- a/src/components/Loader.astro
+++ b/src/components/Loader.astro
@@ -13,7 +13,7 @@ import { css } from '../../styled-system/css';
     display: 'grid',
     placeItems: 'center',
     backgroundColor: '#eeeeee',
-    zIndex: 9999,
+    zIndex: 9999
   })}
 >
   <h1
@@ -21,14 +21,14 @@ import { css } from '../../styled-system/css';
       fontSize: '3rem',
       fontWeight: 700,
       color: '#1a1a1a',
-      clipPath: 'polygon(0 0, 100% 0, 100% 100%, 0% 100%)',
+      clipPath: 'polygon(0 0, 100% 0, 100% 100%, 0% 100%)'
     })}
   >
     <div
       id="loader-text-inner"
       class={css({
         display: 'flex',
-        gap: '0.25em',
+        gap: '0.25em'
       })}
     >
       <span> Now </span>

--- a/src/components/Projects/Projects.astro
+++ b/src/components/Projects/Projects.astro
@@ -10,7 +10,7 @@ import { css } from '../../../styled-system/css';
     height: '100svb',
     backgroundColor: '#212121',
     paddingInline: { base: '16px', sm: '24px', md: '32px' },
-    paddingBlock: '64px',
+    paddingBlock: '64px'
   })}
 >
   <h1
@@ -18,7 +18,7 @@ import { css } from '../../../styled-system/css';
       display: 'inline flex',
       justifyContent: 'start',
       alignItems: 'center',
-      color: 'primary',
+      color: 'primary'
     })}
   >
     Projects

--- a/src/components/Skills/Skills.astro
+++ b/src/components/Skills/Skills.astro
@@ -10,7 +10,7 @@ import { css } from '../../../styled-system/css';
     height: '100svb',
     backgroundColor: '#1a1a1a',
     paddingInline: { base: '16px', sm: '24px', md: '32px' },
-    paddingBlock: '64px',
+    paddingBlock: '64px'
   })}
 >
   <h1
@@ -18,7 +18,7 @@ import { css } from '../../../styled-system/css';
       display: 'inline flex',
       justifyContent: 'start',
       alignItems: 'center',
-      color: 'primary',
+      color: 'primary'
     })}
   >
     Skills

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -53,13 +53,13 @@ const description =
     gsap
       .timeline({
         repeat: -1,
-        repeatDelay: 1,
+        repeatDelay: 1
       })
       .from(split.chars, {
         y: '100%',
         stagger: 0.05,
         duration: 1,
-        ease: 'power4.out',
+        ease: 'power4.out'
       })
       .to(
         loaderText,
@@ -71,9 +71,9 @@ const description =
           delay: 0.5,
           onComplete: () => {
             document.dispatchEvent(new CustomEvent('loader-animation-finished'));
-          },
+          }
         },
-        '-=0.5',
+        '-=0.5'
       )
       .to(
         '#loader',
@@ -86,9 +86,9 @@ const description =
             if (loader) {
               loader.style.display = 'none';
             }
-          },
+          }
         },
-        '-=0.5',
+        '-=0.5'
       );
   };
 

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -383,12 +383,12 @@ interface ServiceWorkerGlobalScope extends WorkerGlobalScope {
 declare function addEventListener<Type extends keyof WorkerGlobalScopeEventMap>(
   type: Type,
   handler: EventListenerOrEventListenerObject<WorkerGlobalScopeEventMap[Type]>,
-  options?: EventTargetAddEventListenerOptions | boolean,
+  options?: EventTargetAddEventListenerOptions | boolean
 ): void;
 declare function removeEventListener<Type extends keyof WorkerGlobalScopeEventMap>(
   type: Type,
   handler: EventListenerOrEventListenerObject<WorkerGlobalScopeEventMap[Type]>,
-  options?: EventTargetEventListenerOptions | boolean,
+  options?: EventTargetEventListenerOptions | boolean
 ): void;
 /**
  * The **`dispatchEvent()`** method of the EventTarget sends an Event to the object, (synchronously) invoking the affected event listeners in the appropriate order.
@@ -396,7 +396,7 @@ declare function removeEventListener<Type extends keyof WorkerGlobalScopeEventMa
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/dispatchEvent)
  */
 declare function dispatchEvent(
-  event: WorkerGlobalScopeEventMap[keyof WorkerGlobalScopeEventMap],
+  event: WorkerGlobalScopeEventMap[keyof WorkerGlobalScopeEventMap]
 ): boolean;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/btoa) */
 declare function btoa(data: string): string;
@@ -431,7 +431,7 @@ declare function reportError(error: any): void;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/fetch) */
 declare function fetch(
   input: RequestInfo | URL,
-  init?: RequestInit<RequestInitCfProperties>,
+  init?: RequestInit<RequestInitCfProperties>
 ): Promise<Response>;
 declare const self: ServiceWorkerGlobalScope;
 /**
@@ -472,48 +472,48 @@ interface ExecutionContext<Props = unknown> {
 type ExportedHandlerFetchHandler<Env = unknown, CfHostMetadata = unknown, Props = unknown> = (
   request: Request<CfHostMetadata, IncomingRequestCfProperties<CfHostMetadata>>,
   env: Env,
-  ctx: ExecutionContext<Props>,
+  ctx: ExecutionContext<Props>
 ) => Response | Promise<Response>;
 type ExportedHandlerConnectHandler<Env = unknown, Props = unknown> = (
   socket: Socket,
   env: Env,
-  ctx: ExecutionContext<Props>,
+  ctx: ExecutionContext<Props>
 ) => void | Promise<void>;
 type ExportedHandlerTailHandler<Env = unknown, Props = unknown> = (
   events: TraceItem[],
   env: Env,
-  ctx: ExecutionContext<Props>,
+  ctx: ExecutionContext<Props>
 ) => void | Promise<void>;
 type ExportedHandlerTraceHandler<Env = unknown, Props = unknown> = (
   traces: TraceItem[],
   env: Env,
-  ctx: ExecutionContext<Props>,
+  ctx: ExecutionContext<Props>
 ) => void | Promise<void>;
 type ExportedHandlerTailStreamHandler<Env = unknown, Props = unknown> = (
   event: TailStream.TailEvent<TailStream.Onset>,
   env: Env,
-  ctx: ExecutionContext<Props>,
+  ctx: ExecutionContext<Props>
 ) => TailStream.TailEventHandlerType | Promise<TailStream.TailEventHandlerType>;
 type ExportedHandlerScheduledHandler<Env = unknown, Props = unknown> = (
   controller: ScheduledController,
   env: Env,
-  ctx: ExecutionContext<Props>,
+  ctx: ExecutionContext<Props>
 ) => void | Promise<void>;
 type ExportedHandlerQueueHandler<Env = unknown, Message = unknown, Props = unknown> = (
   batch: MessageBatch<Message>,
   env: Env,
-  ctx: ExecutionContext<Props>,
+  ctx: ExecutionContext<Props>
 ) => void | Promise<void>;
 type ExportedHandlerTestHandler<Env = unknown, Props = unknown> = (
   controller: TestController,
   env: Env,
-  ctx: ExecutionContext<Props>,
+  ctx: ExecutionContext<Props>
 ) => void | Promise<void>;
 interface ExportedHandler<
   Env = unknown,
   QueueHandlerMessage = unknown,
   CfHostMetadata = unknown,
-  Props = unknown,
+  Props = unknown
 > {
   fetch?: ExportedHandlerFetchHandler<Env, CfHostMetadata, Props>;
   connect?: ExportedHandlerConnectHandler<Env, Props>;
@@ -574,7 +574,7 @@ interface DurableObject {
     ws: WebSocket,
     code: number,
     reason: string,
-    wasClean: boolean,
+    wasClean: boolean
   ): void | Promise<void>;
   webSocketError?(ws: WebSocket, error: unknown): void | Promise<void>;
 }
@@ -592,18 +592,18 @@ interface DurableObjectId {
   readonly jurisdiction?: string;
 }
 declare abstract class DurableObjectNamespace<
-  T extends Rpc.DurableObjectBranded | undefined = undefined,
+  T extends Rpc.DurableObjectBranded | undefined = undefined
 > {
   newUniqueId(options?: DurableObjectNamespaceNewUniqueIdOptions): DurableObjectId;
   idFromName(name: string): DurableObjectId;
   idFromString(id: string): DurableObjectId;
   get(
     id: DurableObjectId,
-    options?: DurableObjectNamespaceGetDurableObjectOptions,
+    options?: DurableObjectNamespaceGetDurableObjectOptions
   ): DurableObjectStub<T>;
   getByName(
     name: string,
-    options?: DurableObjectNamespaceGetDurableObjectOptions,
+    options?: DurableObjectNamespaceGetDurableObjectOptions
   ): DurableObjectStub<T>;
   jurisdiction(jurisdiction: DurableObjectJurisdiction): DurableObjectNamespace<T>;
 }
@@ -705,7 +705,7 @@ declare class WebSocketRequestResponsePair {
 interface DurableObjectFacets {
   get<T extends Rpc.DurableObjectBranded | undefined = undefined>(
     name: string,
-    getStartupOptions: () => FacetStartupOptions<T> | Promise<FacetStartupOptions<T>>,
+    getStartupOptions: () => FacetStartupOptions<T> | Promise<FacetStartupOptions<T>>
   ): Fetcher<T>;
   abort(name: string, reason: any): void;
   delete(name: string): void;
@@ -873,7 +873,7 @@ declare class EventTarget<EventMap extends Record<string, Event> = Record<string
   addEventListener<Type extends keyof EventMap>(
     type: Type,
     handler: EventListenerOrEventListenerObject<EventMap[Type]>,
-    options?: EventTargetAddEventListenerOptions | boolean,
+    options?: EventTargetAddEventListenerOptions | boolean
   ): void;
   /**
    * The **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.
@@ -883,7 +883,7 @@ declare class EventTarget<EventMap extends Record<string, Event> = Record<string
   removeEventListener<Type extends keyof EventMap>(
     type: Type,
     handler: EventListenerOrEventListenerObject<EventMap[Type]>,
-    options?: EventTargetEventListenerOptions | boolean,
+    options?: EventTargetEventListenerOptions | boolean
   ): void;
   /**
    * The **`dispatchEvent()`** method of the EventTarget sends an Event to the object, (synchronously) invoking the affected event listeners in the appropriate order.
@@ -1072,7 +1072,7 @@ declare class File extends Blob {
   constructor(
     bits: ((ArrayBuffer | ArrayBufferView) | string | Blob)[] | undefined,
     name: string,
-    options?: FileOptions,
+    options?: FileOptions
   );
   /**
    * The **`name`** read-only property of the File interface returns the name of the file represented by a File object.
@@ -1151,7 +1151,7 @@ declare abstract class Crypto {
       | Int32Array
       | Uint32Array
       | BigInt64Array
-      | BigUint64Array,
+      | BigUint64Array
   >(buffer: T): T;
   /**
    * The **`randomUUID()`** method of the Crypto interface is used to generate a v4 UUID using a cryptographically secure random number generator.
@@ -1177,7 +1177,7 @@ declare abstract class SubtleCrypto {
   encrypt(
     algorithm: string | SubtleCryptoEncryptAlgorithm,
     key: CryptoKey,
-    plainText: ArrayBuffer | ArrayBufferView,
+    plainText: ArrayBuffer | ArrayBufferView
   ): Promise<ArrayBuffer>;
   /**
    * The **`decrypt()`** method of the SubtleCrypto interface decrypts some encrypted data.
@@ -1187,7 +1187,7 @@ declare abstract class SubtleCrypto {
   decrypt(
     algorithm: string | SubtleCryptoEncryptAlgorithm,
     key: CryptoKey,
-    cipherText: ArrayBuffer | ArrayBufferView,
+    cipherText: ArrayBuffer | ArrayBufferView
   ): Promise<ArrayBuffer>;
   /**
    * The **`sign()`** method of the SubtleCrypto interface generates a digital signature.
@@ -1197,7 +1197,7 @@ declare abstract class SubtleCrypto {
   sign(
     algorithm: string | SubtleCryptoSignAlgorithm,
     key: CryptoKey,
-    data: ArrayBuffer | ArrayBufferView,
+    data: ArrayBuffer | ArrayBufferView
   ): Promise<ArrayBuffer>;
   /**
    * The **`verify()`** method of the SubtleCrypto interface verifies a digital signature.
@@ -1208,7 +1208,7 @@ declare abstract class SubtleCrypto {
     algorithm: string | SubtleCryptoSignAlgorithm,
     key: CryptoKey,
     signature: ArrayBuffer | ArrayBufferView,
-    data: ArrayBuffer | ArrayBufferView,
+    data: ArrayBuffer | ArrayBufferView
   ): Promise<boolean>;
   /**
    * The **`digest()`** method of the SubtleCrypto interface generates a _digest_ of the given data, using the specified hash function.
@@ -1217,7 +1217,7 @@ declare abstract class SubtleCrypto {
    */
   digest(
     algorithm: string | SubtleCryptoHashAlgorithm,
-    data: ArrayBuffer | ArrayBufferView,
+    data: ArrayBuffer | ArrayBufferView
   ): Promise<ArrayBuffer>;
   /**
    * The **`generateKey()`** method of the SubtleCrypto interface is used to generate a new key (for symmetric algorithms) or key pair (for public-key algorithms).
@@ -1227,7 +1227,7 @@ declare abstract class SubtleCrypto {
   generateKey(
     algorithm: string | SubtleCryptoGenerateKeyAlgorithm,
     extractable: boolean,
-    keyUsages: string[],
+    keyUsages: string[]
   ): Promise<CryptoKey | CryptoKeyPair>;
   /**
    * The **`deriveKey()`** method of the SubtleCrypto interface can be used to derive a secret key from a master key.
@@ -1239,7 +1239,7 @@ declare abstract class SubtleCrypto {
     baseKey: CryptoKey,
     derivedKeyAlgorithm: string | SubtleCryptoImportKeyAlgorithm,
     extractable: boolean,
-    keyUsages: string[],
+    keyUsages: string[]
   ): Promise<CryptoKey>;
   /**
    * The **`deriveBits()`** method of the key.
@@ -1249,7 +1249,7 @@ declare abstract class SubtleCrypto {
   deriveBits(
     algorithm: string | SubtleCryptoDeriveKeyAlgorithm,
     baseKey: CryptoKey,
-    length?: number | null,
+    length?: number | null
   ): Promise<ArrayBuffer>;
   /**
    * The **`importKey()`** method of the SubtleCrypto interface imports a key: that is, it takes as input a key in an external, portable format and gives you a CryptoKey object that you can use in the Web Crypto API.
@@ -1261,7 +1261,7 @@ declare abstract class SubtleCrypto {
     keyData: (ArrayBuffer | ArrayBufferView) | JsonWebKey,
     algorithm: string | SubtleCryptoImportKeyAlgorithm,
     extractable: boolean,
-    keyUsages: string[],
+    keyUsages: string[]
   ): Promise<CryptoKey>;
   /**
    * The **`exportKey()`** method of the SubtleCrypto interface exports a key: that is, it takes as input a CryptoKey object and gives you the key in an external, portable format.
@@ -1278,7 +1278,7 @@ declare abstract class SubtleCrypto {
     format: string,
     key: CryptoKey,
     wrappingKey: CryptoKey,
-    wrapAlgorithm: string | SubtleCryptoEncryptAlgorithm,
+    wrapAlgorithm: string | SubtleCryptoEncryptAlgorithm
   ): Promise<ArrayBuffer>;
   /**
    * The **`unwrapKey()`** method of the SubtleCrypto interface 'unwraps' a key.
@@ -1292,7 +1292,7 @@ declare abstract class SubtleCrypto {
     unwrapAlgorithm: string | SubtleCryptoEncryptAlgorithm,
     unwrappedKeyAlgorithm: string | SubtleCryptoImportKeyAlgorithm,
     extractable: boolean,
-    keyUsages: string[],
+    keyUsages: string[]
   ): Promise<CryptoKey>;
   timingSafeEqual(a: ArrayBuffer | ArrayBufferView, b: ArrayBuffer | ArrayBufferView): boolean;
 }
@@ -1666,7 +1666,7 @@ declare class FormData {
   values(): IterableIterator<File | string>;
   forEach<This = unknown>(
     callback: (this: This, value: File | string, key: string, parent: FormData) => void,
-    thisArg?: This,
+    thisArg?: This
   ): void;
   [Symbol.iterator](): IterableIterator<[key: string, value: File | string]>;
 }
@@ -1807,7 +1807,7 @@ declare class Headers {
   delete(name: string): void;
   forEach<This = unknown>(
     callback: (this: This, value: string, key: string, parent: Headers) => void,
-    thisArg?: This,
+    thisArg?: This
   ): void;
   /* Returns an iterator allowing to go through all key/value pairs contained in this object. */
   entries(): IterableIterator<[key: string, value: string]>;
@@ -1931,7 +1931,7 @@ declare var Request: {
   prototype: Request;
   new <CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>>(
     input: RequestInfo<CfProperties> | URL,
-    init?: RequestInit<Cf>,
+    init?: RequestInit<Cf>
   ): Request<CfHostMetadata, Cf>;
 };
 /**
@@ -2021,7 +2021,7 @@ type Service<
     | (new (...args: any[]) => Rpc.WorkerEntrypointBranded)
     | Rpc.WorkerEntrypointBranded
     | ExportedHandler<any, any, any>
-    | undefined = undefined,
+    | undefined = undefined
 > = T extends new (...args: any[]) => Rpc.WorkerEntrypointBranded
   ? Fetcher<InstanceType<T>>
   : T extends Rpc.WorkerEntrypointBranded
@@ -2031,7 +2031,7 @@ type Service<
       : Fetcher<undefined>;
 type Fetcher<
   T extends Rpc.EntrypointBranded | undefined = undefined,
-  Reserved extends string = never,
+  Reserved extends string = never
 > = (T extends Rpc.EntrypointBranded
   ? Rpc.Provider<T, Reserved | 'fetch' | 'connect'>
   : unknown) & {
@@ -2064,90 +2064,90 @@ interface KVNamespace<Key extends string = string> {
   get(key: Key, options?: KVNamespaceGetOptions<'text'>): Promise<string | null>;
   get<ExpectedValue = unknown>(
     key: Key,
-    options?: KVNamespaceGetOptions<'json'>,
+    options?: KVNamespaceGetOptions<'json'>
   ): Promise<ExpectedValue | null>;
   get(key: Key, options?: KVNamespaceGetOptions<'arrayBuffer'>): Promise<ArrayBuffer | null>;
   get(key: Key, options?: KVNamespaceGetOptions<'stream'>): Promise<ReadableStream | null>;
   get(key: Array<Key>, type: 'text'): Promise<Map<string, string | null>>;
   get<ExpectedValue = unknown>(
     key: Array<Key>,
-    type: 'json',
+    type: 'json'
   ): Promise<Map<string, ExpectedValue | null>>;
   get(
     key: Array<Key>,
-    options?: Partial<KVNamespaceGetOptions<undefined>>,
+    options?: Partial<KVNamespaceGetOptions<undefined>>
   ): Promise<Map<string, string | null>>;
   get(
     key: Array<Key>,
-    options?: KVNamespaceGetOptions<'text'>,
+    options?: KVNamespaceGetOptions<'text'>
   ): Promise<Map<string, string | null>>;
   get<ExpectedValue = unknown>(
     key: Array<Key>,
-    options?: KVNamespaceGetOptions<'json'>,
+    options?: KVNamespaceGetOptions<'json'>
   ): Promise<Map<string, ExpectedValue | null>>;
   list<Metadata = unknown>(
-    options?: KVNamespaceListOptions,
+    options?: KVNamespaceListOptions
   ): Promise<KVNamespaceListResult<Metadata, Key>>;
   put(
     key: Key,
     value: string | ArrayBuffer | ArrayBufferView | ReadableStream,
-    options?: KVNamespacePutOptions,
+    options?: KVNamespacePutOptions
   ): Promise<void>;
   getWithMetadata<Metadata = unknown>(
     key: Key,
-    options?: Partial<KVNamespaceGetOptions<undefined>>,
+    options?: Partial<KVNamespaceGetOptions<undefined>>
   ): Promise<KVNamespaceGetWithMetadataResult<string, Metadata>>;
   getWithMetadata<Metadata = unknown>(
     key: Key,
-    type: 'text',
+    type: 'text'
   ): Promise<KVNamespaceGetWithMetadataResult<string, Metadata>>;
   getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(
     key: Key,
-    type: 'json',
+    type: 'json'
   ): Promise<KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>;
   getWithMetadata<Metadata = unknown>(
     key: Key,
-    type: 'arrayBuffer',
+    type: 'arrayBuffer'
   ): Promise<KVNamespaceGetWithMetadataResult<ArrayBuffer, Metadata>>;
   getWithMetadata<Metadata = unknown>(
     key: Key,
-    type: 'stream',
+    type: 'stream'
   ): Promise<KVNamespaceGetWithMetadataResult<ReadableStream, Metadata>>;
   getWithMetadata<Metadata = unknown>(
     key: Key,
-    options: KVNamespaceGetOptions<'text'>,
+    options: KVNamespaceGetOptions<'text'>
   ): Promise<KVNamespaceGetWithMetadataResult<string, Metadata>>;
   getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(
     key: Key,
-    options: KVNamespaceGetOptions<'json'>,
+    options: KVNamespaceGetOptions<'json'>
   ): Promise<KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>;
   getWithMetadata<Metadata = unknown>(
     key: Key,
-    options: KVNamespaceGetOptions<'arrayBuffer'>,
+    options: KVNamespaceGetOptions<'arrayBuffer'>
   ): Promise<KVNamespaceGetWithMetadataResult<ArrayBuffer, Metadata>>;
   getWithMetadata<Metadata = unknown>(
     key: Key,
-    options: KVNamespaceGetOptions<'stream'>,
+    options: KVNamespaceGetOptions<'stream'>
   ): Promise<KVNamespaceGetWithMetadataResult<ReadableStream, Metadata>>;
   getWithMetadata<Metadata = unknown>(
     key: Array<Key>,
-    type: 'text',
+    type: 'text'
   ): Promise<Map<string, KVNamespaceGetWithMetadataResult<string, Metadata>>>;
   getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(
     key: Array<Key>,
-    type: 'json',
+    type: 'json'
   ): Promise<Map<string, KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>>;
   getWithMetadata<Metadata = unknown>(
     key: Array<Key>,
-    options?: Partial<KVNamespaceGetOptions<undefined>>,
+    options?: Partial<KVNamespaceGetOptions<undefined>>
   ): Promise<Map<string, KVNamespaceGetWithMetadataResult<string, Metadata>>>;
   getWithMetadata<Metadata = unknown>(
     key: Array<Key>,
-    options?: KVNamespaceGetOptions<'text'>,
+    options?: KVNamespaceGetOptions<'text'>
   ): Promise<Map<string, KVNamespaceGetWithMetadataResult<string, Metadata>>>;
   getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(
     key: Array<Key>,
-    options?: KVNamespaceGetOptions<'json'>,
+    options?: KVNamespaceGetOptions<'json'>
   ): Promise<Map<string, KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>>;
   delete(key: Key): Promise<void>;
 }
@@ -2176,7 +2176,7 @@ interface Queue<Body = unknown> {
   send(message: Body, options?: QueueSendOptions): Promise<QueueSendResponse>;
   sendBatch(
     messages: Iterable<MessageSendRequest<Body>>,
-    options?: QueueSendBatchOptions,
+    options?: QueueSendBatchOptions
   ): Promise<QueueSendBatchResponse>;
 }
 interface QueueSendMetrics {
@@ -2272,7 +2272,7 @@ interface R2Bucket {
     key: string,
     options: R2GetOptions & {
       onlyIf: R2Conditional | Headers;
-    },
+    }
   ): Promise<R2ObjectBody | R2Object | null>;
   get(key: string, options?: R2GetOptions): Promise<R2ObjectBody | null>;
   put(
@@ -2280,12 +2280,12 @@ interface R2Bucket {
     value: ReadableStream | ArrayBuffer | ArrayBufferView | string | null | Blob,
     options?: R2PutOptions & {
       onlyIf: R2Conditional | Headers;
-    },
+    }
   ): Promise<R2Object | null>;
   put(
     key: string,
     value: ReadableStream | ArrayBuffer | ArrayBufferView | string | null | Blob,
-    options?: R2PutOptions,
+    options?: R2PutOptions
   ): Promise<R2Object>;
   createMultipartUpload(key: string, options?: R2MultipartOptions): Promise<R2MultipartUpload>;
   resumeMultipartUpload(key: string, uploadId: string): R2MultipartUpload;
@@ -2298,7 +2298,7 @@ interface R2MultipartUpload {
   uploadPart(
     partNumber: number,
     value: ReadableStream | (ArrayBuffer | ArrayBufferView) | string | Blob,
-    options?: R2UploadPartOptions,
+    options?: R2UploadPartOptions
   ): Promise<R2UploadedPart>;
   abort(): Promise<void>;
   complete(uploadedParts: R2UploadedPart[]): Promise<R2Object>;
@@ -2524,7 +2524,7 @@ interface ReadableStream<R = any> {
    */
   pipeThrough<T>(
     transform: ReadableWritablePair<T, R>,
-    options?: StreamPipeOptions,
+    options?: StreamPipeOptions
   ): ReadableStream<T>;
   /**
    * The **`pipeTo()`** method of the ReadableStream interface pipes the current `ReadableStream` to a given WritableStream and returns a Promise that fulfills when the piping process completes successfully, or rejects if any errors were encountered.
@@ -2550,11 +2550,11 @@ declare const ReadableStream: {
   prototype: ReadableStream;
   new (
     underlyingSource: UnderlyingByteSource,
-    strategy?: QueuingStrategy<Uint8Array>,
+    strategy?: QueuingStrategy<Uint8Array>
   ): ReadableStream<Uint8Array>;
   new <R = any>(
     underlyingSource?: UnderlyingSource<R>,
-    strategy?: QueuingStrategy<R>,
+    strategy?: QueuingStrategy<R>
   ): ReadableStream<R>;
 };
 /**
@@ -2602,7 +2602,7 @@ declare class ReadableStreamBYOBReader {
   releaseLock(): void;
   readAtLeast<T extends ArrayBufferView>(
     minElements: number,
-    view: T,
+    view: T
   ): Promise<ReadableStreamReadResult<T>>;
 }
 interface ReadableStreamBYOBReaderReadableStreamBYOBReaderReadOptions {
@@ -2860,7 +2860,7 @@ declare class TransformStream<I = any, O = any> {
   constructor(
     transformer?: Transformer<I, O>,
     writableStrategy?: QueuingStrategy<I>,
-    readableStrategy?: QueuingStrategy<O>,
+    readableStrategy?: QueuingStrategy<O>
   );
   /**
    * The **`readable`** read-only property of the TransformStream interface returns the ReadableStream instance controlled by this `TransformStream`.
@@ -2878,7 +2878,7 @@ declare class TransformStream<I = any, O = any> {
 declare class FixedLengthStream extends IdentityTransformStream {
   constructor(
     expectedLength: number | bigint,
-    queuingStrategy?: IdentityTransformStreamQueuingStrategy,
+    queuingStrategy?: IdentityTransformStreamQueuingStrategy
   );
 }
 declare class IdentityTransformStream extends TransformStream<
@@ -3339,7 +3339,7 @@ declare class URLSearchParams {
   values(): IterableIterator<string>;
   forEach<This = unknown>(
     callback: (this: This, value: string, key: string, parent: URLSearchParams) => void,
-    thisArg?: This,
+    thisArg?: This
   ): void;
   /*function toString() { [native code] }*/
   toString(): string;
@@ -3349,7 +3349,7 @@ declare class URLPattern {
   constructor(
     input?: string | URLPatternInit,
     baseURL?: string | URLPatternOptions,
-    patternOptions?: URLPatternOptions,
+    patternOptions?: URLPatternOptions
   );
   get protocol(): string;
   get username(): string;
@@ -3653,7 +3653,7 @@ interface Container {
   interceptOutboundHttp(addr: string, binding: Fetcher): Promise<void>;
   interceptAllOutboundHttp(binding: Fetcher): Promise<void>;
   snapshotDirectory(
-    options: ContainerDirectorySnapshotOptions,
+    options: ContainerDirectorySnapshotOptions
   ): Promise<ContainerDirectorySnapshot>;
   snapshotContainer(options: ContainerSnapshotOptions): Promise<ContainerSnapshot>;
   interceptOutboundHttps(addr: string, binding: Fetcher): Promise<void>;
@@ -3722,7 +3722,7 @@ interface MessagePortPostMessageOptions {
 type LoopbackForExport<
   T extends
     (new (...args: any[]) => Rpc.EntrypointBranded) | ExportedHandler<any, any, any> | undefined =
-    undefined,
+    undefined
 > = T extends new (...args: any[]) => Rpc.WorkerEntrypointBranded
   ? LoopbackServiceStub<InstanceType<T>>
   : T extends new (...args: any[]) => Rpc.DurableObjectBranded
@@ -3759,11 +3759,11 @@ interface SyncKvListOptions {
 interface WorkerStub {
   getEntrypoint<T extends Rpc.WorkerEntrypointBranded | undefined>(
     name?: string,
-    options?: WorkerStubEntrypointOptions,
+    options?: WorkerStubEntrypointOptions
   ): Fetcher<T>;
   getDurableObjectClass<T extends Rpc.DurableObjectBranded | undefined>(
     name?: string,
-    options?: WorkerStubEntrypointOptions,
+    options?: WorkerStubEntrypointOptions
   ): DurableObjectClass<T>;
 }
 interface WorkerStubEntrypointOptions {
@@ -3773,7 +3773,7 @@ interface WorkerStubEntrypointOptions {
 interface WorkerLoader {
   get(
     name: string | null,
-    getCode: () => WorkerLoaderWorkerCode | Promise<WorkerLoaderWorkerCode>,
+    getCode: () => WorkerLoaderWorkerCode | Promise<WorkerLoaderWorkerCode>
   ): WorkerStub;
   load(code: WorkerLoaderWorkerCode): WorkerStub;
 }
@@ -4639,7 +4639,7 @@ declare abstract class AiSearchItems {
   upload(
     name: string,
     content: ReadableStream | Blob | string,
-    options?: AiSearchUploadItemOptions,
+    options?: AiSearchUploadItemOptions
   ): Promise<AiSearchItemInfo>;
   /**
    * Upload a file and poll until processing completes.
@@ -4658,7 +4658,7 @@ declare abstract class AiSearchItems {
       pollIntervalMs?: number;
       /** Maximum time to wait in milliseconds (default 30000). */
       timeoutMs?: number;
-    },
+    }
   ): Promise<AiSearchItemInfo>;
   /**
    * Get an item by ID.
@@ -4747,7 +4747,7 @@ declare abstract class AiSearchInstance {
   chatCompletions(
     params: AiSearchChatCompletionsRequest & {
       stream: true;
-    },
+    }
   ): Promise<ReadableStream>;
   /**
    * Generate chat completions with AI Search context.
@@ -4858,7 +4858,7 @@ declare abstract class AiSearchNamespace {
   chatCompletions(
     params: AiSearchMultiChatCompletionsRequest & {
       stream: true;
-    },
+    }
   ): Promise<ReadableStream>;
   /**
    * Generate chat completions across multiple instances within the bound namespace.
@@ -4867,7 +4867,7 @@ declare abstract class AiSearchNamespace {
    * @returns Chat completion response with choices, chunks tagged by instance_id, and optional partial-failure errors.
    */
   chatCompletions(
-    params: AiSearchMultiChatCompletionsRequest,
+    params: AiSearchMultiChatCompletionsRequest
   ): Promise<AiSearchMultiChatCompletionsResponse>;
 }
 type AiImageClassificationInput = {
@@ -10879,7 +10879,7 @@ declare abstract class Ai<AiModelList extends AiModelListType = AiModels> {
     },
     options: AiOptions & {
       queueRequest: true;
-    },
+    }
   ): Promise<AiAsyncBatchResponse>;
   // Raw response
   run<Name extends keyof AiModelList>(
@@ -10887,7 +10887,7 @@ declare abstract class Ai<AiModelList extends AiModelListType = AiModels> {
     inputs: AiModelList[Name]['inputs'],
     options: AiOptions & {
       returnRawResponse: true;
-    },
+    }
   ): Promise<Response>;
   // WebSocket
   run<Name extends keyof AiModelList>(
@@ -10895,7 +10895,7 @@ declare abstract class Ai<AiModelList extends AiModelListType = AiModels> {
     inputs: AiModelList[Name]['inputs'],
     options: AiOptions & {
       websocket: true;
-    },
+    }
   ): Promise<Response>;
   // Streaming
   run<Name extends keyof AiModelList>(
@@ -10903,13 +10903,13 @@ declare abstract class Ai<AiModelList extends AiModelListType = AiModels> {
     inputs: AiModelList[Name]['inputs'] & {
       stream: true;
     },
-    options?: AiOptions,
+    options?: AiOptions
   ): Promise<ReadableStream>;
   // Normal (default) - known model
   run<Name extends keyof AiModelList>(
     model: Name,
     inputs: AiModelList[Name]['inputs'],
-    options?: AiOptions,
+    options?: AiOptions
   ): Promise<AiModelList[Name]['postProcessedOutputs']>;
   // Unknown model (fallback).
   //
@@ -10922,17 +10922,17 @@ declare abstract class Ai<AiModelList extends AiModelListType = AiModels> {
   run<Model extends string>(
     model: Model extends keyof AiModelList ? never : Model,
     inputs: Record<string, unknown>,
-    options?: AiOptions,
+    options?: AiOptions
   ): Promise<Record<string, unknown>>;
   models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
   toMarkdown(): ToMarkdownService;
   toMarkdown(
     files: MarkdownDocument[],
-    options?: ConversionRequestOptions,
+    options?: ConversionRequestOptions
   ): Promise<ConversionResponse[]>;
   toMarkdown(
     files: MarkdownDocument,
-    options?: ConversionRequestOptions,
+    options?: ConversionRequestOptions
   ): Promise<ConversionResponse>;
 }
 type GatewayRetries = {
@@ -11051,7 +11051,7 @@ declare abstract class AiGateway {
       gateway?: UniversalGatewayOptions;
       extraHeaders?: object;
       signal?: AbortSignal;
-    },
+    }
   ): Promise<Response>;
   getUrl(provider?: AIGatewayProviders | string): Promise<string>; // eslint-disable-line
 }
@@ -11181,7 +11181,7 @@ interface ArtifactsRepo extends ArtifactsRepoInfo {
       description?: string;
       readOnly?: boolean;
       defaultBranchOnly?: boolean;
-    },
+    }
   ): Promise<ArtifactsCreateRepoResult>;
 }
 // ── Error types ──────────────────────────────────────────────────────────────
@@ -11238,7 +11238,7 @@ interface Artifacts {
       readOnly?: boolean;
       description?: string;
       setDefaultBranch?: string;
-    },
+    }
   ): Promise<ArtifactsCreateRepoResult>;
   /**
    * Get a handle to an existing repository.
@@ -13315,7 +13315,7 @@ declare abstract class EmailEvent extends ExtendableEvent {
 declare type EmailExportedHandler<Env = unknown, Props = unknown> = (
   message: ForwardableEmailMessage,
   env: Env,
-  ctx: ExecutionContext<Props>,
+  ctx: ExecutionContext<Props>
 ) => void | Promise<void>;
 declare module 'cloudflare:email' {
   let _EmailMessage: {
@@ -13367,7 +13367,7 @@ declare abstract class Flagship {
   get(
     flagKey: string,
     defaultValue?: unknown,
-    context?: FlagshipEvaluationContext,
+    context?: FlagshipEvaluationContext
   ): Promise<unknown>;
   /**
    * Get a boolean flag value.
@@ -13378,7 +13378,7 @@ declare abstract class Flagship {
   getBooleanValue(
     flagKey: string,
     defaultValue: boolean,
-    context?: FlagshipEvaluationContext,
+    context?: FlagshipEvaluationContext
   ): Promise<boolean>;
   /**
    * Get a string flag value.
@@ -13389,7 +13389,7 @@ declare abstract class Flagship {
   getStringValue(
     flagKey: string,
     defaultValue: string,
-    context?: FlagshipEvaluationContext,
+    context?: FlagshipEvaluationContext
   ): Promise<string>;
   /**
    * Get a number flag value.
@@ -13400,7 +13400,7 @@ declare abstract class Flagship {
   getNumberValue(
     flagKey: string,
     defaultValue: number,
-    context?: FlagshipEvaluationContext,
+    context?: FlagshipEvaluationContext
   ): Promise<number>;
   /**
    * Get an object flag value.
@@ -13411,7 +13411,7 @@ declare abstract class Flagship {
   getObjectValue<T extends object>(
     flagKey: string,
     defaultValue: T,
-    context?: FlagshipEvaluationContext,
+    context?: FlagshipEvaluationContext
   ): Promise<T>;
   /**
    * Get a boolean flag value with full evaluation details.
@@ -13422,7 +13422,7 @@ declare abstract class Flagship {
   getBooleanDetails(
     flagKey: string,
     defaultValue: boolean,
-    context?: FlagshipEvaluationContext,
+    context?: FlagshipEvaluationContext
   ): Promise<FlagshipEvaluationDetails<boolean>>;
   /**
    * Get a string flag value with full evaluation details.
@@ -13433,7 +13433,7 @@ declare abstract class Flagship {
   getStringDetails(
     flagKey: string,
     defaultValue: string,
-    context?: FlagshipEvaluationContext,
+    context?: FlagshipEvaluationContext
   ): Promise<FlagshipEvaluationDetails<string>>;
   /**
    * Get a number flag value with full evaluation details.
@@ -13444,7 +13444,7 @@ declare abstract class Flagship {
   getNumberDetails(
     flagKey: string,
     defaultValue: number,
-    context?: FlagshipEvaluationContext,
+    context?: FlagshipEvaluationContext
   ): Promise<FlagshipEvaluationDetails<number>>;
   /**
    * Get an object flag value with full evaluation details.
@@ -13455,7 +13455,7 @@ declare abstract class Flagship {
   getObjectDetails<T extends object>(
     flagKey: string,
     defaultValue: T,
-    context?: FlagshipEvaluationContext,
+    context?: FlagshipEvaluationContext
   ): Promise<FlagshipEvaluationDetails<T>>;
 }
 /**
@@ -13696,7 +13696,7 @@ interface HostedImagesBinding {
    */
   upload(
     image: ReadableStream<Uint8Array> | ArrayBuffer,
-    options?: ImageUploadOptions,
+    options?: ImageUploadOptions
   ): Promise<ImageMetadata>;
   /**
    * List hosted images with pagination
@@ -13739,7 +13739,7 @@ interface ImageTransformer {
    */
   draw(
     image: ReadableStream<Uint8Array> | ImageTransformer,
-    options?: ImageDrawOptions,
+    options?: ImageDrawOptions
   ): ImageTransformer;
   /**
    * Retrieve the image that results from applying the transforms to the
@@ -13911,7 +13911,7 @@ type EventContext<Env, P extends string, Data> = {
 type PagesFunction<
   Env = unknown,
   Params extends string = any,
-  Data extends Record<string, unknown> = Record<string, unknown>,
+  Data extends Record<string, unknown> = Record<string, unknown>
 > = (context: EventContext<Env, Params, Data>) => Response | Promise<Response>;
 type EventPluginContext<Env, P extends string, Data, PluginArgs> = {
   request: Request<unknown, IncomingRequestCfProperties<unknown>>;
@@ -13932,7 +13932,7 @@ type PagesPluginFunction<
   Env = unknown,
   Params extends string = any,
   Data extends Record<string, unknown> = Record<string, unknown>,
-  PluginArgs = unknown,
+  PluginArgs = unknown
 > = (context: EventPluginContext<Env, Params, Data, PluginArgs>) => Response | Promise<Response>;
 declare module 'assets:*' {
   export const onRequest: PagesFunction;
@@ -13944,7 +13944,7 @@ declare module 'cloudflare:pipelines' {
   export abstract class PipelineTransformationEntrypoint<
     Env = unknown,
     I extends PipelineRecord = PipelineRecord,
-    O extends PipelineRecord = PipelineRecord,
+    O extends PipelineRecord = PipelineRecord
   > {
     protected env: Env;
     protected ctx: ExecutionContext;
@@ -14145,7 +14145,7 @@ declare namespace Rpc {
   // `Reserved` names (e.g. stub method names like `dup()`) and symbols can't be accessed over RPC.
   export type Provider<
     T extends object,
-    Reserved extends string = never,
+    Reserved extends string = never
   > = MaybeCallableProvider<T> &
     Pick<
       {
@@ -14226,7 +14226,7 @@ declare namespace CloudflareWorkersModule {
     scheduled?(controller: ScheduledController): void | Promise<void>;
     tail?(events: TraceItem[]): void | Promise<void>;
     tailStream?(
-      event: TailStream.TailEvent<TailStream.Onset>,
+      event: TailStream.TailEvent<TailStream.Onset>
     ): TailStream.TailEventHandlerType | Promise<TailStream.TailEventHandlerType>;
     test?(controller: TestController): void | Promise<void>;
     trace?(traces: TraceItem[]): void | Promise<void>;
@@ -14246,7 +14246,7 @@ declare namespace CloudflareWorkersModule {
       ws: WebSocket,
       code: number,
       reason: string,
-      wasClean: boolean,
+      wasClean: boolean
     ): void | Promise<void>;
     webSocketError?(ws: WebSocket, error: unknown): void | Promise<void>;
   }
@@ -14259,7 +14259,7 @@ declare namespace CloudflareWorkersModule {
     error: Error;
   };
   export type WorkflowDelayFunction = (
-    input: WorkflowDynamicDelayContext,
+    input: WorkflowDynamicDelayContext
   ) => WorkflowDelayDuration | Promise<WorkflowDelayDuration>;
   export type WorkflowTimeoutDuration = WorkflowSleepDuration;
   export type WorkflowRetentionDuration = WorkflowSleepDuration;
@@ -14321,7 +14321,7 @@ declare namespace CloudflareWorkersModule {
     stepName: string;
   };
   export type WorkflowRollbackHandler<T = unknown> = (
-    ctx: WorkflowRollbackContext<T>,
+    ctx: WorkflowRollbackContext<T>
   ) => Promise<void>;
   export type WorkflowStepRollbackOptions<T = unknown> = {
     rollback: WorkflowRollbackHandler<T>;
@@ -14331,7 +14331,7 @@ declare namespace CloudflareWorkersModule {
     do<T extends Rpc.Serializable<T>>(
       name: string,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
-      rollbackOptions?: WorkflowStepRollbackOptions<T>,
+      rollbackOptions?: WorkflowStepRollbackOptions<T>
     ): Promise<T>;
     do<T extends Rpc.Serializable<T>, const C extends WorkflowStepConfig>(
       name: string,
@@ -14343,9 +14343,9 @@ declare namespace CloudflareWorkersModule {
           }
             ? D
             : WorkflowDelayDuration | number
-        >,
+        >
       ) => Promise<T>,
-      rollbackOptions?: WorkflowStepRollbackOptions<T>,
+      rollbackOptions?: WorkflowStepRollbackOptions<T>
     ): Promise<T>;
     sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
     sleepUntil: (name: string, timestamp: Date | number) => Promise<void>;
@@ -14354,7 +14354,7 @@ declare namespace CloudflareWorkersModule {
       options: {
         type: string;
         timeout?: WorkflowTimeoutDuration | number;
-      },
+      }
     ): Promise<WorkflowStepEvent<T>>;
   }
   export type WorkflowInstanceStatus =
@@ -14369,7 +14369,7 @@ declare namespace CloudflareWorkersModule {
     | 'unknown';
   export abstract class WorkflowEntrypoint<
     Env = unknown,
-    T extends Rpc.Serializable<T> | unknown = unknown,
+    T extends Rpc.Serializable<T> | unknown = unknown
   >
     implements Rpc.WorkflowEntrypointBranded
   {
@@ -14385,7 +14385,7 @@ declare namespace CloudflareWorkersModule {
   export function withEnvAndExports(
     newEnv: unknown,
     newExports: unknown,
-    fn: () => unknown,
+    fn: () => unknown
   ): unknown;
   export const env: Cloudflare.Env;
   export const exports: Cloudflare.Exports;
@@ -15194,11 +15194,11 @@ type SupportedFileFormat = {
 declare abstract class ToMarkdownService {
   transform(
     files: MarkdownDocument[],
-    options?: ConversionRequestOptions,
+    options?: ConversionRequestOptions
   ): Promise<ConversionResponse[]>;
   transform(
     files: MarkdownDocument,
-    options?: ConversionRequestOptions,
+    options?: ConversionRequestOptions
   ): Promise<ConversionResponse>;
   supported(): Promise<SupportedFileFormat[]>;
 }
@@ -15417,7 +15417,7 @@ declare namespace TailStream {
     readonly event: Event;
   }
   type TailEventHandler<Event extends EventType = EventType> = (
-    event: TailEvent<Event>,
+    event: TailEvent<Event>
   ) => void | Promise<void>;
   type TailEventHandlerObject = {
     outcome?: TailEventHandler<Outcome>;
@@ -15608,7 +15608,7 @@ declare abstract class VectorizeIndex {
    */
   public query(
     vector: VectorFloatArray | number[],
-    options?: VectorizeQueryOptions,
+    options?: VectorizeQueryOptions
   ): Promise<VectorizeMatches>;
   /**
    * Insert a list of vectors into the index dataset. If a provided id exists, an error will be thrown.
@@ -15654,7 +15654,7 @@ declare abstract class Vectorize {
    */
   public query(
     vector: VectorFloatArray | number[],
-    options?: VectorizeQueryOptions,
+    options?: VectorizeQueryOptions
   ): Promise<VectorizeMatches>;
   /**
    * Use the provided vector-id to perform a similarity search across the index.
@@ -15832,7 +15832,7 @@ interface DispatchNamespace {
     args?: {
       [key: string]: any;
     },
-    options?: DynamicDispatchOptions,
+    options?: DynamicDispatchOptions
   ): Fetcher;
 }
 declare module 'cloudflare:workflows' {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,8 +9,8 @@
   "compatibility_flags": ["nodejs_compat"],
   "pages_build_output_dir": "./dist",
   "observability": {
-    "enabled": true,
-  },
+    "enabled": true
+  }
   /**
    * Smart Placement
    * Docs: https://developers.cloudflare.com/workers/configuration/smart-placement/#smart-placement


### PR DESCRIPTION
## 変更内容

- prettierの`trailingComma`を`'all'`から`'none'`に変更
- 上記変更に伴い全ファイルにフォーマットを適用（末尾カンマ削除）
- package.jsonの`format`スクリプトを`--check`から`--write`に修正